### PR TITLE
fix hanging issue when tls is declined

### DIFF
--- a/Sources/MySQLNIO/MySQLConnection.swift
+++ b/Sources/MySQLNIO/MySQLConnection.swift
@@ -24,7 +24,7 @@ public final class MySQLConnection: MySQLDatabase {
             return channel.pipeline.addHandlers([
                 ByteToMessageHandler(MySQLPacketDecoder(sequence: sequence)),
                 MessageToByteHandler(MySQLPacketEncoder(sequence: sequence)),
-                MySQLConnectionHandler(state: .handshake(.init(
+                MySQLConnectionHandler(logger: logger, state: .handshake(.init(
                     username: username,
                     database: database,
                     password: password,

--- a/Sources/MySQLNIO/Protocol/MySQLProtocol+CapabilityFlags.swift
+++ b/Sources/MySQLNIO/Protocol/MySQLProtocol+CapabilityFlags.swift
@@ -143,8 +143,7 @@ extension MySQLProtocol {
             .CLIENT_PLUGIN_AUTH,
             .CLIENT_SECURE_CONNECTION,
             .CLIENT_CONNECT_WITH_DB,
-            .CLIENT_DEPRECATE_EOF,
-            .CLIENT_SSL
+            .CLIENT_DEPRECATE_EOF
         ]
         
         /// All capabilities.


### PR DESCRIPTION
Fixes an issue where connect would hang infinitely if `tlsConfiguration` was set to `nil`. This was because the `CLIENT_SSL` capability was accidentally enabled by default last release and that causes MySQL to always setup TLS. 

Some additional trace logs were added as well to help future debugging.