### PR TITLE
Massive repairs to MySQL server authentication

### DIFF
--- a/Sources/MySQLNIO/MySQLConnection.swift
+++ b/Sources/MySQLNIO/MySQLConnection.swift
@@ -41,7 +41,11 @@ public final class MySQLConnection: MySQLDatabase {
                 ], position: .last).map {
                     return MySQLConnection(channel: channel, logger: .init(label: "codes.vapor.mysql"))
                 }.flatMap { conn in
-                    return done.futureResult.map { conn }
+                    return done.futureResult
+                        .flatMapError { error in
+                            conn.close().recover { _ in }.flatMapThrowing { throw error }
+                        }
+                        .map { conn }
             }
         }
     }

--- a/Sources/MySQLNIO/MySQLError.swift
+++ b/Sources/MySQLNIO/MySQLError.swift
@@ -3,6 +3,10 @@ import Foundation
 public enum MySQLError: Error, CustomStringConvertible, LocalizedError {
     case secureConnectionRequired
     case unsupportedAuthPlugin(name: String)
+    case authPluginDataError(name: String)
+    case missingOrInvalidAuthMoreDataStatusTag
+    case missingOrInvalidAuthPluginInlineCommand(command: UInt8?)
+    case missingAuthPluginInlineData
     case unsupportedServer(message: String)
     case protocolError
     case server(MySQLProtocol.ERR_Packet)
@@ -14,6 +18,14 @@ public enum MySQLError: Error, CustomStringConvertible, LocalizedError {
             return "A secure connection to the server is required for authentication."
         case .unsupportedAuthPlugin(let name):
             return "Unsupported auth plugin name: \(name)"
+        case .authPluginDataError(let name):
+            return "Auth plugin (name: \(name)) sent invalid authentication data."
+        case .missingOrInvalidAuthMoreDataStatusTag:
+            return "Auth plugin didn't send a correct status tag per protocol."
+        case .missingOrInvalidAuthPluginInlineCommand(let byte):
+            return "Auth plugin sent \(byte.map { "\($0)" } ?? "<nothing>"), which we can't interpret."
+        case .missingAuthPluginInlineData:
+            return "Auth plugin was supposed to send us some data."
         case .unsupportedServer(let message):
             return "Unsupported server: \(message)"
         case .protocolError:

--- a/Sources/MySQLNIO/Utilities/CryptoUtils.swift
+++ b/Sources/MySQLNIO/Utilities/CryptoUtils.swift
@@ -15,11 +15,18 @@ func sha1(_ messages: ByteBuffer...) -> ByteBuffer {
 }
 
 func xor(_ a: ByteBuffer, _ b: ByteBuffer) -> ByteBuffer {
-    var a = a
-    var b = b
-    var output = ByteBufferAllocator().buffer(capacity: min(a.readableBytes, b.readableBytes))
-    while let a = a.readInteger(as: UInt8.self), let b = b.readInteger(as: UInt8.self) {
-        output.writeInteger(a ^ b)
+    assert(a.readableBytes == b.readableBytes)
+    var output = ByteBufferAllocator().buffer(capacity: a.readableBytes)
+    for i in 0..<a.readableBytes {
+        output.writeInteger(a.getInteger(at: i, as: UInt8.self)! ^ b.getInteger(at: i, as: UInt8.self)!)
+    }
+    return output
+}
+
+func xor_pattern(_ a: ByteBuffer, _ b: ByteBuffer) -> ByteBuffer {
+    var output = ByteBufferAllocator().buffer(capacity: a.readableBytes)
+    for i in 0..<a.readableBytes {
+        output.writeInteger(a.getInteger(at: i, as: UInt8.self)! ^ b.getInteger(at: i % b.readableBytes, as: UInt8.self)!)
     }
     return output
 }

--- a/Sources/MySQLNIO/Utilities/PEMDecodableSSLPublicKey.swift
+++ b/Sources/MySQLNIO/Utilities/PEMDecodableSSLPublicKey.swift
@@ -1,0 +1,141 @@
+import NIOSSL
+#if compiler(>=5.1) && compiler(<5.3)
+@_implementationOnly import CNIOBoringSSL
+#else
+import CNIOBoringSSL
+#endif
+
+enum MoreNIOSSLErrors: Error {
+    case failedToLoadPublicKey
+    
+    /// To add final insult to the injury of all this copy-pasta, thanks to the differing typealias,
+    /// we can't even use the original error enum itself in the end.
+    case unknownBoringSSLError(MoreNIOBoringSSLNotCoweringInCupertinoErrorStack)
+
+    public static var unknownStack: Self {
+        return .unknownBoringSSLError(self.buildNotUnreasonablyHiddenErrorStack())
+    }
+
+    /// For some reason, this utility on `BoringSSLError` is not public, so now we
+    /// duplicate it exactly here, with the accompanying maintenance burden, even
+    /// though we don't need our own version for any reason.
+    public static func buildNotUnreasonablyHiddenErrorStack() -> MoreNIOBoringSSLNotCoweringInCupertinoErrorStack {
+        var errorStack = MoreNIOBoringSSLNotCoweringInCupertinoErrorStack()
+        
+        while true {
+            let errorCode = CNIOBoringSSL_ERR_get_error()
+            if errorCode == 0 { break }
+            errorStack.append(BoringSSLInternalButLegitimateAndUsableError(errorCode: errorCode))
+        }
+        return errorStack
+    }
+}
+
+/// Same goes for this entire struct. Absurd.
+public struct BoringSSLInternalButLegitimateAndUsableError: Equatable, CustomStringConvertible {
+    public let errorCode: UInt32
+
+    public var errorMessage: String {
+        var scratchBuffer = [CChar](repeating: 0, count: 512)
+        return scratchBuffer.withUnsafeMutableBufferPointer { pointer in
+            CNIOBoringSSL_ERR_error_string_n(self.errorCode, pointer.baseAddress!, pointer.count)
+            return String(cString: pointer.baseAddress!)
+        }
+    }
+
+    public var description: String { "Error: \(errorCode) \(errorMessage)" }
+    public init(errorCode: UInt32) { self.errorCode = errorCode }
+}
+
+/// And because we changed the struct's name, we can't use the existing
+/// typealias, even though that's the one thing that DID bother being public!!
+public typealias MoreNIOBoringSSLNotCoweringInCupertinoErrorStack = [BoringSSLInternalButLegitimateAndUsableError]
+
+/// It turns out there are _no_ public ways whatsoever to create an
+/// `NIOSSLPublicKey`, even though all we wanted to do was add a way to invoke
+/// one the same way the private and X.509 types can be invoked. So now we have
+/// to copy the whole bloody thing.
+public class MoreNIOSSLPublicKey {
+    private let _ref: UnsafeMutableRawPointer /*<EVP_PKEY>*/
+
+    private var ref: UnsafeMutablePointer<EVP_PKEY> {
+        return self._ref.assumingMemoryBound(to: EVP_PKEY.self)
+    }
+
+    fileprivate init(withOwnedReference ref: UnsafeMutablePointer<EVP_PKEY>) {
+        self._ref = UnsafeMutableRawPointer(ref) // erasing the type for @_implementationOnly import CNIOBoringSSL
+    }
+
+    deinit {
+        CNIOBoringSSL_EVP_PKEY_free(self.ref)
+    }
+
+    /// Create an NIOSSLPrivateKey from a buffer of bytes in either PEM or
+    /// DER format.
+    ///
+    /// - parameters:
+    ///     - bytes: The key bytes.
+    ///     - format: The format of the key to load, either DER or PEM.
+    public convenience init(bytes: [UInt8], format: NIOSSLSerializationFormats) throws {
+        let ref = bytes.withUnsafeBytes { (ptr) -> UnsafeMutablePointer<EVP_PKEY>? in
+            let bio = CNIOBoringSSL_BIO_new_mem_buf(ptr.baseAddress!, CInt(ptr.count))!
+            defer {
+                CNIOBoringSSL_BIO_free(bio)
+            }
+
+            switch format {
+            case .pem:
+                return CNIOBoringSSL_PEM_read_bio_PUBKEY(bio, nil, { _, _, _, _  in -1 }, nil)
+            case .der:
+                return CNIOBoringSSL_d2i_PUBKEY_bio(bio, nil)
+            }
+        }
+
+        if ref == nil {
+            throw MoreNIOSSLErrors.failedToLoadPublicKey
+        }
+
+        self.init(withOwnedReference: ref!)
+    }
+}
+
+// MARK:- Utilities
+extension MoreNIOSSLPublicKey {
+    /// Perform an RSA asymmetric "encrypt" operation, such that the matching private key for this public key
+    /// is required to later decrypt the result and recover the original plaintext. This function allocates,
+    /// somewhat out of necessity. The use of PKCS#1 OAEP padding is hardcoded at this time. This is the padding
+    /// used by MySQL's "caching_sha2_password" plugin. The return value is the resultant ciphertext, already
+    /// padded according to PKCS#1 rules. This function can only encrypt a single "block"; it does not implement
+    /// any codebook modes whatsoever. An input which exceeds the limit will be rejected, not truncated
+    public func encrypt(bytes: [UInt8]) throws -> [UInt8] {
+        guard let context = CNIOBoringSSL_EVP_PKEY_CTX_new(self.ref, nil) else {
+            throw MoreNIOSSLErrors.unknownStack
+        }
+        defer { CNIOBoringSSL_EVP_PKEY_CTX_free(context) }
+        
+        guard CNIOBoringSSL_EVP_PKEY_encrypt_init(context) > 0 else { throw MoreNIOSSLErrors.unknownStack }
+        guard CNIOBoringSSL_EVP_PKEY_CTX_set_rsa_padding(context, RSA_PKCS1_OAEP_PADDING) > 0 else { throw MoreNIOSSLErrors.unknownStack }
+        
+        var ciphertextLength: Int = 0
+        
+        return try bytes.withUnsafeBufferPointer { inputBuffer in
+            guard CNIOBoringSSL_EVP_PKEY_encrypt(context, nil, &ciphertextLength, inputBuffer.baseAddress, inputBuffer.count) > 0 else {
+                throw MoreNIOSSLErrors.unknownStack
+            }
+            
+            return try [UInt8].init(unsafeUninitializedCapacity: ciphertextLength) { outputBuffer, outCount in
+                outCount = ciphertextLength
+                guard CNIOBoringSSL_EVP_PKEY_encrypt(context, outputBuffer.baseAddress, &outCount, inputBuffer.baseAddress, inputBuffer.count) > 0 else {
+                    throw MoreNIOSSLErrors.unknownStack
+                }
+            }
+        }
+    }
+
+    public static func ==(lhs: MoreNIOSSLPublicKey, rhs: MoreNIOSSLPublicKey) -> Bool {
+        // Annoyingly, EVP_PKEY_cmp does not have a traditional return value pattern. 1 means equal, 0 means non-equal,
+        // negative means error. Here we treat "error" as "not equal", because we have no error reporting mechanism from this call site,
+        // and anyway, BoringSSL considers "these keys aren't of the same type" to be an error, which is in my mind pretty ludicrous.
+        return CNIOBoringSSL_EVP_PKEY_cmp(lhs.ref, rhs.ref) == 1
+    }
+}

--- a/Tests/MySQLNIOTests/NIOMySQLTests.swift
+++ b/Tests/MySQLNIOTests/NIOMySQLTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import Logging
 @testable import MySQLNIO
 
 final class NIOMySQLTests: XCTestCase {
@@ -348,11 +349,21 @@ final class NIOMySQLTests: XCTestCase {
         }
     }
     
-    override func setUp() {
+    override func setUpWithError() throws {
+        XCTAssert(isLoggingConfigured)
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
     }
     
-    override func tearDown() {
-        try! self.group.syncShutdownGracefully()
+    override func tearDownWithError() throws {
+        try self.group.syncShutdownGracefully()
     }
 }
+
+let isLoggingConfigured: Bool = {
+    LoggingSystem.bootstrap { label in
+        var handler = StreamLogHandler.standardOutput(label: label)
+        handler.logLevel = .debug
+        return handler
+    }
+    return true
+}()

--- a/Tests/MySQLNIOTests/Utilities.swift
+++ b/Tests/MySQLNIOTests/Utilities.swift
@@ -3,18 +3,20 @@ import NIOSSL
 
 extension MySQLConnection {
     static func test(on eventLoop: EventLoop) -> EventLoopFuture<MySQLConnection> {
+        let addr: SocketAddress
         do {
-            return try self.connect(
-                to: .makeAddressResolvingHost(env("MYSQL_HOSTNAME") ?? "localhost", port: 3306),
-                username: "vapor_username",
-                database: "vapor_database",
-                password: "vapor_password",
-                tlsConfiguration: .forClient(certificateVerification: .none),
-                on: eventLoop
-            )
+            addr = try SocketAddress.makeAddressResolvingHost(env("MYSQL_HOSTNAME") ?? "localhost", port: 3306)
         } catch {
             return eventLoop.makeFailedFuture(error)
         }
+        return self.connect(
+            to: addr,
+            username: "vapor_username",
+            database: "vapor_database",
+            password: "vapor_password",
+            tlsConfiguration: .forClient(certificateVerification: .none),
+            on: eventLoop
+        )
     }
 }
 

--- a/Tests/MySQLNIOTests/Utilities.swift
+++ b/Tests/MySQLNIOTests/Utilities.swift
@@ -14,7 +14,7 @@ extension MySQLConnection {
             username: "vapor_username",
             database: "vapor_database",
             password: "vapor_password",
-            tlsConfiguration: .forClient(certificateVerification: .none),
+            tlsConfiguration: nil,
             on: eventLoop
         )
     }


### PR DESCRIPTION
- Connecting to MySQL 8.0 servers now works over both TLS and non-TLS.
- Connecting to MySQL 8.0 servers configured to use `caching_sha2_password` now works.
- Connecting to MySQL 8.0 servers configured to use `mysql_native_password` by default but `caching_sha2_password` for specific users now works.
- The "caching" part of `caching_sha2_password` now works.
- Failing to authenticate to a server while `.wait()`-ing on a new connection no longer crashes.
- It is no longer necessary to disable TLS certificate validation at any time (though TLS connections do still require trusted certificates).