### PR TITLE
Decode string from tiny, medium and long blob

### DIFF
--- a/Sources/MySQLNIO/MySQLData.swift
+++ b/Sources/MySQLNIO/MySQLData.swift
@@ -173,7 +173,7 @@ public struct MySQLData: CustomStringConvertible, ExpressibleByStringLiteral, Ex
             return buffer.readString(length: buffer.readableBytes)
         default:
             switch self.type {
-            case .varchar, .varString, .string, .blob:
+            case .varchar, .varString, .string, .blob, .tinyBlob, .mediumBlob, .longBlob:
                 return buffer.readString(length: buffer.readableBytes)
             case .longlong, .long, .int24, .short, .tiny, .bit:
                 return self.int?.description


### PR DESCRIPTION
Adds support for `.tinyBlob`, `.mediumBlob`, and `.longBlob` to `MySQLData.string` (#26, fixes https://github.com/vapor/mysql-kit/issues/275).