### PR TITLE
Rmann/fix constraint error

### DIFF
--- a/Sources/MySQLNIO/MySQLError.swift
+++ b/Sources/MySQLNIO/MySQLError.swift
@@ -8,6 +8,9 @@ public enum MySQLError: Error, CustomStringConvertible, LocalizedError {
     case server(MySQLProtocol.ERR_Packet)
     case closed
     
+    /// A uniqueness constraint violated. Associated value is message from server with details.
+    case duplicateEntry(String)
+    
     public var message: String {
         switch self {
         case .secureConnectionRequired:
@@ -22,6 +25,8 @@ public enum MySQLError: Error, CustomStringConvertible, LocalizedError {
             return "Server error: \(error.errorMessage)"
         case .closed:
             return "Connection closed."
+        case .duplicateEntry(let message):
+            return "Duplicate entry: \(message)"
         }
     }
     

--- a/Sources/MySQLNIO/MySQLError.swift
+++ b/Sources/MySQLNIO/MySQLError.swift
@@ -8,7 +8,7 @@ public enum MySQLError: Error, CustomStringConvertible, LocalizedError {
     case server(MySQLProtocol.ERR_Packet)
     case closed
     
-    /// A uniqueness constraint violated. Associated value is message from server with details.
+    /// A uniqueness constraint was violated. Associated value is message from server with details.
     case duplicateEntry(String)
     
     public var message: String {

--- a/Sources/MySQLNIO/MySQLQueryCommand.swift
+++ b/Sources/MySQLNIO/MySQLQueryCommand.swift
@@ -83,7 +83,13 @@ private final class MySQLQueryCommand: MySQLCommand {
         guard !packet.isError else {
             self.state = .done
             let error = try packet.decode(MySQLProtocol.ERR_Packet.self, capabilities: capabilities)
-            throw MySQLError.server(error)
+            switch error.errorCode {
+                case .DUP_ENTRY:
+                    let msg = error.errorMessage
+                    throw MySQLError.duplicateEntry(msg)
+                default:
+                    throw MySQLError.server(error)
+            }
         }
         switch self.state {
         case .ready:

--- a/Tests/MySQLNIOTests/NIOMySQLTests.swift
+++ b/Tests/MySQLNIOTests/NIOMySQLTests.swift
@@ -143,12 +143,8 @@ final class NIOMySQLTests: XCTestCase {
         let insertResults = try conn.query("INSERT INTO foos VALUES (?, ?)", [1, "one"]).wait()
         XCTAssertEqual(insertResults.count, 0)
         XCTAssertThrowsError(try conn.query("INSERT INTO foos VALUES (?, ?)", [1, "two"]).wait()) { (inError) in
-            let e = inError as! MySQLError
-            switch e {
-                case .duplicateEntry(_):
-                    break
-                default:
-                    XCTFail("Wrong error thrown")
+            guard case .duplicateEntry = inError as? MySQLError else {
+                return XCTFail("Expected MySQLError.duplicateEntry, but found \(inError)")
             }
         }
     }

--- a/Tests/MySQLNIOTests/NIOMySQLTests.swift
+++ b/Tests/MySQLNIOTests/NIOMySQLTests.swift
@@ -133,6 +133,26 @@ final class NIOMySQLTests: XCTestCase {
         }
     }
     
+    func testQuery_duplicateEntry() throws {
+        let conn = try MySQLConnection.test(on: self.eventLoop).wait()
+        defer { try! conn.close().wait() }
+        let dropResults = try conn.simpleQuery("DROP TABLE IF EXISTS foos").wait()
+        XCTAssertEqual(dropResults.count, 0)
+        let createResults = try conn.simpleQuery("CREATE TABLE foos (id BIGINT SIGNED unique, name VARCHAR(64))").wait()
+        XCTAssertEqual(createResults.count, 0)
+        let insertResults = try conn.query("INSERT INTO foos VALUES (?, ?)", [1, "one"]).wait()
+        XCTAssertEqual(insertResults.count, 0)
+        XCTAssertThrowsError(try conn.query("INSERT INTO foos VALUES (?, ?)", [1, "two"]).wait()) { (inError) in
+            let e = inError as! MySQLError
+            switch e {
+                case .duplicateEntry(_):
+                    break
+                default:
+                    XCTFail("Wrong error thrown")
+            }
+        }
+    }
+    
     func testQuery_selectMixed() throws {
         let conn = try MySQLConnection.test(on: self.eventLoop).wait()
         defer { try! conn.close().wait() }


### PR DESCRIPTION
The MySQL support wasn't properly detecting duplicate key constraint violations. This change adds `MySQLError.duplicateEntry()` and associated unit test. A separate PR fixes the constraint test in `fluent-mysql-driver`.