### PR TITLE
Copy row byte buffer slices

### DIFF
--- a/Sources/MySQLNIO/Protocol/MySQLProtocol+BinaryResultSetRow.swift
+++ b/Sources/MySQLNIO/Protocol/MySQLProtocol+BinaryResultSetRow.swift
@@ -24,17 +24,21 @@ extension MySQLProtocol {
                 if nullBitmap.isNull(at: i) {
                     storage = nil
                 } else {
+                    var slice: ByteBuffer
                     if let length = column.columnType.encodingLength {
                         guard let data = packet.payload.readSlice(length: length) else {
                             fatalError()
                         }
-                        storage = data
+                        slice = data
                     } else {
                         guard let data = packet.payload.readLengthEncodedSlice() else {
                             fatalError()
                         }
-                        storage = data
+                        slice = data
                     }
+                    var copy = ByteBufferAllocator().buffer(capacity: slice.readableBytes)
+                    copy.writeBuffer(&slice)
+                    storage = copy
                 }
                 values.append(storage)
             }


### PR DESCRIPTION
Fixes an issue causing MySQLRow to retain large amounts of memory (#28). 

> Note: Adds an explicit copy to MySQLRow value byte buffer slices allowing wire protocol buffers to be released from memory. 