### PR TITLE
MySQL driver no longer crashes on auth failures

### DIFF
--- a/Sources/MySQLNIO/MySQLConnection.swift
+++ b/Sources/MySQLNIO/MySQLConnection.swift
@@ -38,10 +38,8 @@ public final class MySQLConnection: MySQLDatabase {
                     done: done
                 )), sequence: sequence),
                 ErrorHandler()
-                ], position: .last).map {
-                    return MySQLConnection(channel: channel, logger: .init(label: "codes.vapor.mysql"))
-                }.flatMap { conn in
-                    return done.futureResult.map { conn }
+            ], position: .last).flatMap {
+                return done.futureResult.map { MySQLConnection(channel: channel, logger: logger) }
             }
         }
     }


### PR DESCRIPTION
- Fix a user-unsolvable crash triggered by any failure whatsoever during the wire protocol handshake.
- Propagate loggers a bit better.

See Git commit log for a detailed explanation of the problem and its solution.

No API changes or additions.