### PR TITLE
Fix statement close on error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,7 +78,14 @@ jobs:
     container: 
       image: vapor/swift:5.2
     services:
-      mysql:
+      mysql-a:
+        image: mysql
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: true
+          MYSQL_DATABASE: vapor_database
+          MYSQL_USER: vapor_username
+          MYSQL_PASSWORD: vapor_password
+      mysql-b:
         image: mysql
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: true
@@ -94,4 +101,5 @@ jobs:
     - run: swift test --enable-test-discovery --sanitize=thread
       working-directory: ./fluent-mysql-driver
       env:
-        MYSQL_HOSTNAME: mysql
+        MYSQL_HOSTNAME_A: mysql-a
+        MYSQL_HOSTNAME_B: mysql-b

--- a/Sources/MySQLNIO/MySQLConnectionHandler.swift
+++ b/Sources/MySQLNIO/MySQLConnectionHandler.swift
@@ -254,7 +254,11 @@ final class MySQLConnectionHandler: ChannelDuplexHandler {
         if commandState.done {
             let current = self.queue.removeFirst()
             self.commandState = .ready
-            current.promise.succeed(())
+            if let error = commandState.error {
+                current.promise.fail(error)
+            } else {
+                current.promise.succeed(())
+            }
             self.sendEnqueuedCommandIfReady(context: context)
         }
         if commandState.resetSequence {

--- a/Sources/MySQLNIO/MySQLDatabase.swift
+++ b/Sources/MySQLNIO/MySQLDatabase.swift
@@ -21,11 +21,18 @@ public struct MySQLCommandState {
     let response: [MySQLPacket]
     let done: Bool
     let resetSequence: Bool
+    var error: Error?
     
-    public init(response: [MySQLPacket] = [], done: Bool = false, resetSequence: Bool = false) {
+    public init(
+        response: [MySQLPacket] = [],
+        done: Bool = false,
+        resetSequence: Bool = false,
+        error: Error? = nil
+    ) {
         self.response = response
         self.done = done
         self.resetSequence = resetSequence
+        self.error = error
     }
 }
 

--- a/Sources/MySQLNIO/MySQLQueryCommand.swift
+++ b/Sources/MySQLNIO/MySQLQueryCommand.swift
@@ -176,12 +176,15 @@ private final class MySQLQueryCommand: MySQLCommand {
             }
         }
         var packet = MySQLPacket()
-        MySQLProtocol.COM_STMT_CLOSE(statementID: self.ok!.statementID).encode(into: &packet)
-        if let error = self.lastUserError {
-            throw error
-        } else {
-            return .init(response: [packet], done: true, resetSequence: true)
-        }
+        MySQLProtocol.COM_STMT_CLOSE(
+            statementID: self.ok!.statementID
+        ).encode(into: &packet)
+        return .init(
+            response: [packet],
+            done: true,
+            resetSequence: true,
+            error: self.lastUserError
+        )
     }
     
     func activate(capabilities: MySQLProtocol.CapabilityFlags) throws -> MySQLCommandState {

--- a/Tests/MySQLNIOTests/Utilities.swift
+++ b/Tests/MySQLNIOTests/Utilities.swift
@@ -17,7 +17,3 @@ extension MySQLConnection {
         }
     }
 }
-
-private func env(_ name: String) -> String? {
-    getenv(name).flatMap { String(cString: $0) }
-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,15 @@
 version: '3'
 
 services:
+  test:
+    image: mysql
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+      MYSQL_DATABASE: vapor_database
+      MYSQL_USER: vapor_username
+      MYSQL_PASSWORD: vapor_password
+    ports:
+      - 3306:3306
   mysql-8_0:
     image: mysql:8.0
     environment:


### PR DESCRIPTION
Fixes a bug causing query statements to not be cleaned up (closed) if an error was thrown in the `onRow` callback (#32, fixes https://github.com/vapor/mysql-nio/issues/30).