### PR TITLE
Fix statement close during binding

### DIFF
--- a/Sources/MySQLNIO/MySQLQueryCommand.swift
+++ b/Sources/MySQLNIO/MySQLQueryCommand.swift
@@ -204,7 +204,7 @@ private final class MySQLQueryCommand: MySQLCommand {
         ).encode(into: &packet)
         self.statementID = nil
         return .init(
-            response: [],
+            response: [packet],
             done: true,
             resetSequence: true,
             error: self.lastUserError
@@ -218,5 +218,8 @@ private final class MySQLQueryCommand: MySQLCommand {
 
     deinit {
         assert(self.statementID == nil, "Statement not closed: \(self.sql)")
+        if self.statementID != nil {
+            self.logger.error("Statement not closed: \(self.sql)")
+        }
     }
 }

--- a/Tests/MySQLNIOTests/MySQLNIOTests.swift
+++ b/Tests/MySQLNIOTests/MySQLNIOTests.swift
@@ -440,7 +440,7 @@ final class MySQLNIOTests: XCTestCase {
 let isLoggingConfigured: Bool = {
     LoggingSystem.bootstrap { label in
         var handler = StreamLogHandler.standardOutput(label: label)
-        handler.logLevel = env("LOG_LEVEL").flatMap { Logger.Level(rawValue: $0) } ?? .debug
+        handler.logLevel = env("LOG_LEVEL").flatMap { Logger.Level(rawValue: $0) } ?? .info
         return handler
     }
     return true

--- a/Tests/MySQLNIOTests/NIOMySQLTests.swift
+++ b/Tests/MySQLNIOTests/NIOMySQLTests.swift
@@ -416,6 +416,16 @@ final class MySQLNIOTests: XCTestCase {
             }
         }
     }
+    func testPreparedStatement_invalidParams() throws {
+        let conn = try MySQLConnection.test(on: self.eventLoop).wait()
+        defer { try! conn.close().wait() }
+
+        do {
+            _ = try conn.query("SELECT ?", []).wait()
+        } catch MySQLError.server {
+            // Pass
+        }
+    }
     
     override func setUp() {
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,13 @@ version: '3'
 
 services:
   test:
-    image: mysql
+    image: mysql:5.7
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "true"
       MYSQL_DATABASE: vapor_database
       MYSQL_USER: vapor_username
       MYSQL_PASSWORD: vapor_password
+      MYSQL_ROOT_PASSWORD: secret
     ports:
       - 3306:3306
   mysql-8_0:


### PR DESCRIPTION
Fixes an issue causing prepared statements to not close if an error happened during parameter binding (#34). 

> notes: MySQL NIO will now assert that statements have been closed before the query handler deinitializes. 