### PR TITLE
Add server version check

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,3 +37,13 @@ services:
       MYSQL_PASSWORD: vapor_password
     ports:
       - 3306:3306
+  # unsupported: for testing errors
+  mysql-5_6:
+    image: mysql:5.6
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+      MYSQL_DATABASE: vapor_database
+      MYSQL_USER: vapor_username
+      MYSQL_PASSWORD: vapor_password
+    ports:
+      - 3306:3306


### PR DESCRIPTION
Adds a check to ensure the server version is supported (#41, fixes #39). 

Unsupported MySQL server versions will now log an error during handshake.