### PR TITLE
Docs + missing functionality

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -1,0 +1,29 @@
+# Contributing to MySQLNIO
+
+👋 Welcome to the Vapor team! 
+
+## Testing
+
+To run this package's tests, you need to start a local MySQL database. The easiest way to do this is using Docker.
+
+If you have Docker installed and running, you can use the `docker-compose` included with this package. The following command will download the required files and boot a local MySQL server:
+
+```fish
+docker-compose up mysql
+```
+
+Run this in the project's root folder (where the `docker-compose.yml` file is). Check out that file to see the other versions of MySQL you can test against.
+
+Once you have a server running, you can run the test suite from Xcode by hitting `CMD+u` or from the command line:
+
+```fish
+swift test
+```
+
+Make sure to add tests for any new code you write.
+
+----------
+
+Join us on Discord if you have any questions: [http://vapor.team](http://vapor.team).
+
+&mdash; Thanks! 🙌

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ import MySQLNIO
 
 let eventLoop: EventLoop = ...
 let conn = try MySQLConnection(
-    to: .makeAddressResolvingHost("my.psql.server", port: 5432),
+    to: .makeAddressResolvingHost("my.mysql.server", port: 5432),
     username: "vapor_username",
     database: "vapor_database",
     password: "vapor_password",

--- a/README.md
+++ b/README.md
@@ -1,20 +1,217 @@
-<p align="center">
-    <img src="https://user-images.githubusercontent.com/1342803/75577086-35280780-5a2f-11ea-8eb2-2044b0310f49.png" height="64" alt="MySQLNIO">
-    <br>
-    <br>
-    <a href="https://docs.vapor.codes/4.0/">
-        <img src="http://img.shields.io/badge/read_the-docs-2196f3.svg" alt="Documentation">
-    </a>
-    <a href="https://discord.gg/vapor">
-        <img src="https://img.shields.io/discord/431917998102675485.svg" alt="Team Chat">
-    </a>
-    <a href="LICENSE">
-        <img src="http://img.shields.io/badge/license-MIT-brightgreen.svg" alt="MIT License">
-    </a>
-    <a href="https://github.com/vapor/mysql-nio/actions">
-        <img src="https://github.com/vapor/mysql-nio/workflows/test/badge.svg" alt="CI">
-    </a>
-    <a href="https://swift.org">
-        <img src="http://img.shields.io/badge/swift-5.2-brightgreen.svg" alt="Swift 5.2">
-    </a>
-</p>
+<img src="https://user-images.githubusercontent.com/1342803/75577086-35280780-5a2f-11ea-8eb2-2044b0310f49.png" height="64" alt="MySQLNIO">
+
+<a href="https://docs.vapor.codes/4.0/">
+    <img src="http://img.shields.io/badge/read_the-docs-2196f3.svg" alt="Documentation">
+</a>
+<a href="https://discord.gg/vapor">
+    <img src="https://img.shields.io/discord/431917998102675485.svg" alt="Team Chat">
+</a>
+<a href="LICENSE">
+    <img src="http://img.shields.io/badge/license-MIT-brightgreen.svg" alt="MIT License">
+</a>
+<a href="https://github.com/vapor/mysql-nio/actions">
+    <img src="https://github.com/vapor/mysql-nio/workflows/test/badge.svg" alt="CI">
+</a>
+<a href="https://swift.org">
+    <img src="http://img.shields.io/badge/swift-5.2-brightgreen.svg" alt="Swift 5.2">
+</a>
+<br>
+<br>
+
+🐬 Non-blocking, event-driven Swift client for MySQL built on [SwiftNIO](https://github.com/apple/swift-nio).
+
+### Major Releases
+
+The table below shows a list of PostgresNIO major releases alongside their compatible NIO and Swift versions. 
+
+|Version|NIO|Swift|SPM|
+|---|---|---|---|
+|1.0|2.0+|5.2+|`from: "1.0.0"`|
+
+Use the SPM string to easily include the dependendency in your `Package.swift` file.
+
+```swift
+.package(url: "https://github.com/vapor/mysql-nio.git", from: ...)
+```
+
+### Supported Platforms
+
+MySQLNIO supports the following platforms:
+
+- Ubuntu 16.04, 18.04, 20.04
+- macOS 10.15, 11
+- CentOS 8
+- Amazon Linux 2
+
+## Overview
+
+MySQLNIO is a client package for connecting to, authorizing, and querying a MySQL server. At the heart of this module are NIO channel handlers for parsing and serializing messages in MySQL's proprietary wire protocol. These channel handlers are combined in a request / response style connection type that provides a convenient, client-like interface for performing queries. 
+
+Support for both simple (text) and parameterized (prepared statement) querying is provided out of the box alongside a `MySQLData` type that handles conversion between MySQL's wire format and native Swift types.
+
+### Motivation
+
+Most Swift implementations of MySQL clients are based on the [libmysqlclient](https://dev.mysql.com/doc/c-api/5.7/en/c-api-implementations.html) C library which handles transport internally. Building a library directly on top of MySQL's wire protocol using SwiftNIO should yield a more reliable, maintainable, and performant interface for MySQL databases.
+
+### Goals
+
+This package is meant to be a low-level, unopinionated MySQL wire-protocol implementation for Swift. The hope is that higher level packages can share MySQLNIO as a foundation for interacting with MySQL servers without needing to duplicate complex logic.
+
+Because of this, MySQLNIO excludes some important concepts for the sake of simplicity, such as:
+
+- Connection pooling
+- Swift `Codable` integration
+- Query building
+
+If you are looking for a MySQL client package to use in your project, take a look at these higher-level packages built on top of MySQLNIO:
+
+- [`vapor/mysql-kit`](https://github.com/vapor/mysql-kit)
+
+### Dependencies
+
+This package has four dependencies:
+
+- [`apple/swift-nio`](https://github.com/apple/swift-nio) for IO
+- [`apple/swift-nio-ssl`](https://github.com/apple/swift-nio-ssl) for TLS
+- [`apple/swift-log`](https://github.com/apple/swift-log) for logging
+- [`apple/swift-crypto`](https://github.com/apple/swift-crypto) for cryptography
+
+This package has no additional system dependencies.
+
+## API Docs
+
+Check out the [MySQLNIO API docs](https://api.vapor.codes/mysql-nio/master/MySQLNIO/index.html) for a detailed look at all of the classes, structs, protocols, and more.
+
+## Getting Started
+
+This section will provide a quick look at using MySQLNIO.
+
+### Creating a Connection
+
+The first step to making a query is creating a new `MySQLConnection`. The minimum requirements to create one are a `SocketAddress`, `EventLoop`, and credentials. 
+
+```swift
+import MySQLNIO
+
+let eventLoop: EventLoop = ...
+let conn = try MySQLConnection(
+    to: .makeAddressResolvingHost("my.psql.server", port: 5432),
+    username: "vapor_username",
+    database: "vapor_database",
+    password: "vapor_password",
+    on: eventLoop
+).wait()
+```
+
+Note: These examples will make use of `wait()` for simplicity. This is appropriate if you are using MySQLNIO on the main thread, like for a CLI tool or in tests. However, you should never use `wait()` on an event loop.
+
+There are a few ways to create a `SocketAddress`:
+
+- `init(ipAddress: String, port: Int)`
+- `init(unixDomainSocketPath: String)`
+- `makeAddressResolvingHost(_ host: String, port: Int)`
+
+There are also some additional arguments you can supply to `connect`. 
+
+- `tlsConfiguration` An optional `TLSConfiguration` struct. This will be used if the MySQL server supports TLS. Pass `nil` to opt-out of TLS.
+- `serverHostname` An optional `String` to use in conjunction with `tlsConfiguration` to specify the server's hostname. 
+
+`connect` will return a future `MySQLConnection`, or an error if it could not connect.
+
+### Database Protocol
+
+Interaction with a server revolves around the `MySQLDatabase` protocol. This protocol includes methods like `query(_:)` for executing SQL queries and reading the resulting rows. 
+
+`MySQLConnection` is the default implementation of `MySQLDatabase` provided by this package. Assume the client here is the connection from the previous example.
+
+```swift
+import MySQLNIO
+
+let db: MySQLDatabase = ...
+// now we can use client to do queries
+```
+
+### Simple Query
+
+Simple (text) queries allow you to execute a SQL string on the connected MySQL server. These queries do not support binding parameters, so any values sent must be escaped manually.
+
+These queries are most useful for schema or transactional queries, or simple selects. Note that values returned by simple queries will be transferred in the less efficient text format. 
+
+`simpleQuery` has two overloads, one that returns an array of rows, and one that accepts a closure for handling each row as it is returned.
+
+```swift
+let rows = try db.simpleQuery("SELECT @@version").wait()
+print(rows) // [["@@version": "8.x.x"]]
+
+try db.simpleQuery("SELECT @@version") { row in
+    print(row) // ["@@version": "8.x.x"]
+}.wait()
+```
+
+### Parameterized Query
+
+Parameterized (prepared statement) queries allow you to execute a SQL string on the connected MySQL server. These queries support passing bound parameters as a separate argument. Each parameter is represented in the SQL string using placeholders (`?`). 
+
+These queries are most useful for selecting, inserting, and updating data. Data for these queries is transferred using the highly efficient binary format. 
+
+Just like `simpleQuery`, `query` also offers two overloads. One that returns an array of rows, and one that accepts a closure for handling each row as it is returned.
+
+```swift
+let rows = try db.query("SELECT * FROM planets WHERE name = ?", ["Earth"]).wait()
+print(rows) // [["id": 42, "name": "Earth"]]
+
+try db.query("SELECT * FROM planets WHERE name = ?", ["Earth"]) { row in
+    print(row) // ["id": 42, "name": "Earth"]
+}.wait()
+```
+
+### Rows and Data
+
+Both `simpleQuery` and `query` return the same `MySQLRow` type. Columns can be fetched from the row using the `column(_:table:)` method.
+
+```swift
+let row: MySQLRow = ...
+let version = row.column("name")
+print(version) // MySQLData?
+```
+
+`MySQLRow` columns are stored as `MySQLData`. This struct contains the raw bytes returned by MySQL as well as some information for parsing them, such as:
+
+- MySQL data type
+- Wire format: binary or text
+- Value as array of bytes
+
+`MySQLData` has a variety of convenience methods for converting column data to usable Swift types.
+
+```swift
+let data: MySQLData = ...
+
+print(data.string) // String?
+
+print(data.int) // Int?
+print(data.int8) // Int8?
+print(data.int16) // Int16?
+print(data.int32) // Int32?
+print(data.int64) // Int64?
+
+print(data.uint) // UInt?
+print(data.uint8) // UInt8?
+print(data.uint16) // UInt16?
+print(data.uint32) // UInt32?
+print(data.uint64) // UInt64?
+
+print(data.bool) // Bool?
+
+try print(data.json(as: Foo.self)) // Foo?
+
+print(data.float) // Float?
+print(data.double) // Double?
+
+print(data.date) // Date?
+print(data.uuid) // UUID?
+print(data.decimal) // Decimal?
+
+print(data.time) // MySQLTime?
+```
+
+`MySQLData` is also used for sending data _to_ the server via parameterized values. To create `MySQLData` from a Swift type, use the available intializer methods. 

--- a/Sources/MySQLNIO/MySQLConnection.swift
+++ b/Sources/MySQLNIO/MySQLConnection.swift
@@ -7,6 +7,7 @@ public final class MySQLConnection: MySQLDatabase {
         database: String,
         password: String? = nil,
         tlsConfiguration: TLSConfiguration? = .forClient(),
+        serverHostname: String? = nil,
         logger: Logger = .init(label: "codes.vapor.mysql"),
         on eventLoop: EventLoop
     ) -> EventLoopFuture<MySQLConnection> {
@@ -35,6 +36,7 @@ public final class MySQLConnection: MySQLDatabase {
                     database: database,
                     password: password,
                     tlsConfiguration: tlsConfiguration,
+                    serverHostname: serverHostname,
                     done: done
                 )), sequence: sequence),
                 ErrorHandler()

--- a/Sources/MySQLNIO/MySQLConnectionHandler.swift
+++ b/Sources/MySQLNIO/MySQLConnectionHandler.swift
@@ -21,6 +21,7 @@ final class MySQLConnectionHandler: ChannelDuplexHandler {
         let database: String
         let password: String?
         let tlsConfiguration: TLSConfiguration?
+        let serverHostname: String?
         let done: EventLoopPromise<Void>
     }
     
@@ -101,7 +102,7 @@ final class MySQLConnectionHandler: ChannelDuplexHandler {
             context.flush()
 
             let sslContext = try NIOSSLContext(configuration: tlsConfiguration)
-            let handler = try NIOSSLClientHandler(context: sslContext, serverHostname: nil)
+            let handler = try NIOSSLClientHandler(context: sslContext, serverHostname: state.serverHostname)
             promise.futureResult.flatMap {
                 return context.channel.pipeline.addHandler(handler, position: .first).flatMapThrowing {
                     try self.writeHandshakeResponse(context: context, handshakeRequest: handshakeRequest, state: state, isTLS: true)

--- a/Sources/MySQLNIO/MySQLData.swift
+++ b/Sources/MySQLNIO/MySQLData.swift
@@ -329,51 +329,93 @@ public struct MySQLData: CustomStringConvertible, ExpressibleByStringLiteral, Ex
     }
     
     public var int: Int? {
+        self.fwi()
+    }
+
+    public var int8: Int8? {
+        self.fwi()
+    }
+
+    public var int16: Int16? {
+        self.fwi()
+    }
+
+    public var int32: Int32? {
+        self.fwi()
+    }
+
+    public var int64: Int64? {
+        self.fwi()
+    }
+
+    public var uint: UInt? {
+        self.fwi()
+    }
+
+    public var uint8: UInt8? {
+        self.fwi()
+    }
+
+    public var uint16: UInt16? {
+        self.fwi()
+    }
+
+    public var uint32: UInt32? {
+        self.fwi()
+    }
+
+    public var uint64: UInt64? {
+        self.fwi()
+    }
+
+    private func fwi<I>(_ type: I.Type = I.self) -> I?
+        where I: FixedWidthInteger
+    {
         guard var buffer = self.buffer else {
             return nil
         }
         switch format {
         case .text:
-            return buffer.readString(length: buffer.readableBytes).flatMap(Int.init)
+            return buffer.readString(length: buffer.readableBytes).flatMap(I.init)
         default:
             switch self.type {
             case .varchar, .varString:
-                return buffer.readString(length: buffer.readableBytes).flatMap(Int.init)
+                return buffer.readString(length: buffer.readableBytes).flatMap(I.init)
             case .longlong:
                 if self.isUnsigned {
                     return buffer.readInteger(endianness: .little, as: UInt64.self)
-                        .flatMap(Int.init)
+                        .flatMap(I.init)
                 } else {
                     return buffer.readInteger(endianness: .little, as: Int64.self)
-                        .flatMap(Int.init)
+                        .flatMap(I.init)
                 }
             case .long, .int24:
                 if self.isUnsigned {
                     return buffer.readInteger(endianness: .little, as: UInt32.self)
-                        .flatMap(Int.init)
+                        .flatMap(I.init)
                 } else {
                     return buffer.readInteger(endianness: .little, as: Int32.self)
-                        .flatMap(Int.init)
+                        .flatMap(I.init)
                 }
             case .short:
                 if self.isUnsigned {
                     return buffer.readInteger(endianness: .little, as: UInt16.self)
-                        .flatMap(Int.init)
+                        .flatMap(I.init)
                 } else {
                     return buffer.readInteger(endianness: .little, as: Int16.self)
-                        .flatMap(Int.init)
+                        .flatMap(I.init)
                 }
             case .tiny, .bit:
                 if self.isUnsigned {
                     return buffer.readInteger(endianness: .little, as: UInt8.self)
-                        .flatMap(Int.init)
+                        .flatMap(I.init)
                 } else {
                     return buffer.readInteger(endianness: .little, as: Int8.self)
-                        .flatMap(Int.init)
+                        .flatMap(I.init)
                 }
             case .newdecimal:
                 return buffer.readString(length: buffer.readableBytes)
-                    .flatMap(Int.init)
+                    .flatMap(I.init)
             default:
                 return nil
             }


### PR DESCRIPTION
Adds docs and implements missing functionality from PostgresNIO (#52).

- Adds `README` docs.
- Adds `contributing.md` docs
- Adds missing `MySQLData` fixed-width integer properties (`int8`, `int16`, `uint32`, etc).
- Adds `serverHostname` parameter to `MySQLConnection.connect`.