### PR TITLE
Major fixes to authentication support

### DIFF
--- a/Sources/MySQLNIO/MySQLConnectionHandler.swift
+++ b/Sources/MySQLNIO/MySQLConnectionHandler.swift
@@ -29,6 +29,8 @@ final class MySQLConnectionHandler: ChannelDuplexHandler {
         var authPluginName: String
         var password: String?
         var isTLS: Bool
+        var savedSeedValue: [UInt8]
+        var awaitingCachingSha2PluginPublicKey: Bool
         var done: EventLoopPromise<Void>
     }
     
@@ -57,12 +59,14 @@ final class MySQLConnectionHandler: ChannelDuplexHandler {
         switch self.state {
         case .handshake(let state):
             do {
+                self.logger.trace("Handle handshake packet")
                 try self.handleHandshake(context: context, packet: &packet, state: state)
             } catch {
                 state.done.fail(error)
             }
         case .authenticating(let state):
             do {
+                self.logger.trace("Handle authentication packet")
                 try self.handleAuthentication(context: context, packet: &packet, state: state)
             } catch {
                 state.done.fail(error)
@@ -115,6 +119,50 @@ final class MySQLConnectionHandler: ChannelDuplexHandler {
         }
     }
     
+    func doInitialAuthPluginHandling(
+        authPluginName: String,
+        isTLS: Bool,
+        passwordInput: String?,
+        authPluginData: ByteBuffer,
+        done: EventLoopPromise<Void>
+    ) throws -> ByteBuffer {
+        var password = ByteBufferAllocator().buffer(capacity: 0)
+        if let passwordString = passwordInput {
+            password.writeString(passwordString)
+        }
+
+        self.logger.trace("Generating initial auth response with auth plugin: \(authPluginName) tls: \(isTLS)")
+
+        var saveSeed: [UInt8] = []
+        let hash: ByteBuffer
+        switch authPluginName {
+        case "caching_sha2_password":
+            let seed = authPluginData
+            hash = xor(sha256(password), sha256(sha256(sha256(password)), seed))
+            saveSeed = seed.getBytes(at: 0, length: seed.readableBytes) ?? []
+            self.logger.trace("Generated scrambled hash for caching_sha2_password")
+        case "mysql_native_password":
+            var copy = authPluginData
+            guard let salt = copy.readSlice(length: 20) else {
+                throw MySQLError.authPluginDataError(name: authPluginName)
+            }
+            hash = xor(sha1(salt, sha1(sha1(password))), sha1(password))
+            saveSeed = salt.getBytes(at: 0, length: 20) ?? []
+            self.logger.trace("Generated salted hash for mysql_native_password")
+        default:
+            throw MySQLError.unsupportedAuthPlugin(name: authPluginName)
+        }
+        self.state = .authenticating(.init(
+            authPluginName: authPluginName,
+            password: passwordInput,
+            isTLS: isTLS,
+            savedSeedValue: saveSeed,
+            awaitingCachingSha2PluginPublicKey: false,
+            done: done
+        ))
+        return hash
+    }
+
     func writeHandshakeResponse(
         context: ChannelHandlerContext,
         handshakeRequest: MySQLProtocol.HandshakeV10,
@@ -168,34 +216,9 @@ final class MySQLConnectionHandler: ChannelDuplexHandler {
         guard let authPluginName = handshakeRequest.authPluginName else {
             throw MySQLError.unsupportedAuthPlugin(name: "<none>")
         }
-        
-        var password = ByteBufferAllocator().buffer(capacity: 0)
-        if let passwordString = state.password {
-            password.writeString(passwordString)
-        }
 
-        self.logger.trace("Writing handshake response with auth plugin: \(authPluginName) tls: \(isTLS)")
+        let hash = try doInitialAuthPluginHandling(authPluginName: authPluginName, isTLS: isTLS, passwordInput: state.password, authPluginData: handshakeRequest.authPluginData, done: state.done)
 
-        let hash: ByteBuffer
-        switch authPluginName {
-        case "caching_sha2_password":
-            let seed = handshakeRequest.authPluginData
-            hash = xor(sha256(password), sha256(sha256(sha256(password)), seed))
-        case "mysql_native_password":
-            var copy = handshakeRequest.authPluginData
-            guard let salt = copy.readSlice(length: 20) else {
-                throw MySQLError.protocolError
-            }
-            hash = xor(sha1(salt, sha1(sha1(password))), sha1(password))
-        default:
-            throw MySQLError.unsupportedAuthPlugin(name: authPluginName)
-        }
-        self.state = .authenticating(.init(
-            authPluginName: authPluginName,
-            password: state.password,
-            isTLS: isTLS,
-            done: state.done
-        ))
         let res = MySQLPacket.HandshakeResponse41(
             capabilities: .clientDefault,
             maxPacketSize: 0,
@@ -209,6 +232,25 @@ final class MySQLConnectionHandler: ChannelDuplexHandler {
         context.flush()
     }
     
+    func handleSwitchPlugins(
+        context: ChannelHandlerContext,
+        packet: inout MySQLPacket,
+        state: AuthenticationState
+    ) throws {
+        self.logger.trace("Got request to switch auth methods (currently \(state.authPluginName)")
+        guard let newPluginName = packet.payload.readNullTerminatedString() else {
+            throw MySQLError.missingAuthPluginInlineData
+        }
+        self.logger.trace("New plugin is \(newPluginName)")
+        guard let newAuthData = packet.payload.readSlice(length: 20) else { // WARNING: This might be wrong for plugins we don't yet support...
+            throw MySQLError.missingAuthPluginInlineData
+        }
+        let newHash = try doInitialAuthPluginHandling(authPluginName: newPluginName, isTLS: state.isTLS, passwordInput: state.password, authPluginData: newAuthData, done: state.done)
+        // Send an AuthSwitchResponse (which is just the plugin auth data by itself)
+        context.write(self.wrapOutboundOut(MySQLPacket(payload: newHash)), promise: nil)
+        context.flush()
+    }
+
     func handleAuthentication(
         context: ChannelHandlerContext,
         packet: inout MySQLPacket,
@@ -217,47 +259,95 @@ final class MySQLConnectionHandler: ChannelDuplexHandler {
         switch state.authPluginName {
         case "caching_sha2_password":
             guard !packet.isOK else {
+                self.logger.trace("caching_sha2_password replied OK, going to command phase")
                 self.state = .commandPhase
                 state.done.succeed(())
                 return
             }
             guard !packet.isError else {
+                self.logger.trace("caching_sha2_password replied ERR, decoding")
                 let err = try packet.decode(MySQLProtocol.ERR_Packet.self, capabilities: self.serverCapabilities!)
                 throw MySQLError.server(err)
             }
             guard let status = packet.payload.readInteger(endianness: .little, as: UInt8.self) else {
-                throw MySQLError.protocolError
+                throw MySQLError.missingOrInvalidAuthMoreDataStatusTag
             }
+            self.logger.trace("caching_sha2_password sent packet tagged \(status)")
             switch status {
+            case 0xfe: // auth switch request
+                try self.handleSwitchPlugins(context: context, packet: &packet, state: state)
             case 0x01:
-                guard let name = packet.payload.readInteger(endianness: .little, as: UInt8.self) else {
-                    throw MySQLError.protocolError
-                }
-                switch name {
-                case 0x04:
-                    guard state.isTLS else {
-                        throw MySQLError.secureConnectionRequired
+                self.logger.trace("caching_sha2_password sent AuthMoreData, processing")
+                let name: UInt8?
+                if state.awaitingCachingSha2PluginPublicKey {
+                    self.logger.trace("Waiting for caching_sha2_password to send an RSA key")
+                    name = nil
+                } else {
+                    guard let pName = packet.payload.readInteger(endianness: .little, as: UInt8.self) else {
+                        throw MySQLError.missingOrInvalidAuthPluginInlineCommand(command: nil)
                     }
+                    name = pName
+                    self.logger.trace("caching_sha2_password sent command \(pName)")
+                }
+                self.state = .authenticating(AuthenticationState(authPluginName: state.authPluginName, password: state.password, isTLS: state.isTLS, savedSeedValue: state.savedSeedValue, awaitingCachingSha2PluginPublicKey: false, done: state.done)) // make sure to reset
+
+                switch name {
+                case .none: // our internal sentinel for "here's the public key" for non-TLS connections
+                    // data will be the PEM form of the server's RSA public key
+                    guard let _/*pemKeyRaw*/ = packet.payload.readBytes(length: packet.payload.readableBytes) else {
+                        throw MySQLError.missingAuthPluginInlineData
+                    }
+                    // TODO: We currently bail out here because we don't have the RSA implementation necessary to
+                    // actually perform the encryption that MySQL wants for this type of connection. We only let
+                    // it get this far because we hope to plug an RSA implementation in at some later time.
+                    self.logger.error("Non-TLS connections can not currently authenticate with the caching SHA-2 plugin, try mysql_native_password auth instead")
+                    throw MySQLError.secureConnectionRequired
+                case 0x03: // fast_auth_success
+                    // Next packet will be OK, wait for more data
+                    self.logger.trace("caching_sha2_password sent fast_auth_success, just waiting for OK now")
+                    return
+                case 0x04: // perform_full_authentication
                     var payload = ByteBufferAllocator().buffer(capacity: 0)
-                    payload.writeNullTerminatedString(state.password ?? "")
+                    if state.isTLS {
+                        // TLS connection, send password in the "clear"
+                        self.logger.trace("caching_sha2_password sent perform_full_authentication on TLS, sending password in cleartext")
+                        payload.writeNullTerminatedString(state.password ?? "")
+                    } else {
+                        // send a public key request and wait
+                        self.logger.trace("caching_sha2_password sent perform_full_authentication on insecure, sending request_public_key")
+                        payload.writeBytes([0x02])
+                        self.state = .authenticating(AuthenticationState(authPluginName: state.authPluginName, password: state.password, isTLS: state.isTLS, savedSeedValue: state.savedSeedValue, awaitingCachingSha2PluginPublicKey: true, done: state.done))
+                    }
                     context.write(self.wrapOutboundOut(MySQLPacket(payload: payload)), promise: nil)
                     context.flush()
                 default:
-                    throw MySQLError.protocolError
+                    throw MySQLError.missingOrInvalidAuthPluginInlineCommand(command: name)
                 }
             default:
-                throw MySQLError.protocolError
+                throw MySQLError.missingOrInvalidAuthMoreDataStatusTag
             }
         case "mysql_native_password":
             guard !packet.isError else {
+                self.logger.trace("mysql_native_password sent ERR, decoding")
                 let error = try packet.decode(MySQLProtocol.ERR_Packet.self, capabilities: self.serverCapabilities!)
                 throw MySQLError.server(error)
             }
-            guard packet.isOK else {
-                throw MySQLError.protocolError
+            guard !packet.isOK else {
+                self.logger.trace("mysql_native_password sent OK, going to command phase")
+                self.state = .commandPhase
+                state.done.succeed(())
+                return
             }
-            self.state = .commandPhase
-            state.done.succeed(())
+            guard let tag = packet.payload.readInteger(endianness: .little, as: UInt8.self) else {
+                throw MySQLError.missingOrInvalidAuthMoreDataStatusTag
+            }
+            self.logger.trace("mysql_native_password sent packet tagged \(tag)")
+            switch tag {
+            case 0xfe: // auth switch request
+                try self.handleSwitchPlugins(context: context, packet: &packet, state: state)
+            default:
+                throw MySQLError.missingOrInvalidAuthPluginInlineCommand(command: tag)
+            }
         default:
             throw MySQLError.unsupportedAuthPlugin(name: state.authPluginName)
         }

--- a/Sources/MySQLNIO/MySQLError.swift
+++ b/Sources/MySQLNIO/MySQLError.swift
@@ -3,6 +3,10 @@ import Foundation
 public enum MySQLError: Error, CustomStringConvertible, LocalizedError {
     case secureConnectionRequired
     case unsupportedAuthPlugin(name: String)
+    case authPluginDataError(name: String)
+    case missingOrInvalidAuthMoreDataStatusTag
+    case missingOrInvalidAuthPluginInlineCommand(command: UInt8?)
+    case missingAuthPluginInlineData
     case unsupportedServer(message: String)
     case protocolError
     case server(MySQLProtocol.ERR_Packet)
@@ -17,6 +21,14 @@ public enum MySQLError: Error, CustomStringConvertible, LocalizedError {
             return "A secure connection to the server is required for authentication."
         case .unsupportedAuthPlugin(let name):
             return "Unsupported auth plugin name: \(name)"
+        case .authPluginDataError(let name):
+            return "Auth plugin (name: \(name)) sent invalid authentication data."
+        case .missingOrInvalidAuthMoreDataStatusTag:
+            return "Auth plugin didn't send a correct status tag per protocol."
+        case .missingOrInvalidAuthPluginInlineCommand(let byte):
+            return "Auth plugin sent \(byte.map { "\($0)" } ?? "<nothing>"), which we can't interpret."
+        case .missingAuthPluginInlineData:
+            return "Auth plugin was supposed to send us some data."
         case .unsupportedServer(let message):
             return "Unsupported server: \(message)"
         case .protocolError:

--- a/Sources/MySQLNIO/MySQLTime.swift
+++ b/Sources/MySQLNIO/MySQLTime.swift
@@ -93,7 +93,7 @@ public struct MySQLTime: Equatable, MySQLDataConvertible {
             return nil
         }
         ctime.tm_year = numericCast(year) - 1900
-        ctime.tm_mon = numericCast(month - 1)
+        ctime.tm_mon = numericCast(month) - 1
         ctime.tm_mday = numericCast(day)
         if
             let hour = self.hour,

--- a/Sources/MySQLNIO/Packet/MySQLPacket.swift
+++ b/Sources/MySQLNIO/Packet/MySQLPacket.swift
@@ -29,7 +29,7 @@ public struct MySQLPacket {
 extension MySQLPacket: CustomStringConvertible {
     public var description: String {
         let bytes = [UInt8](self.payload.readableBytesView)
-        return "\(bytes) (err: \(self.isError), ok: \(self.isOK), eof: \(self.isEOF))"
+        return "\(bytes.prefix(16))... (err: \(self.isError), ok: \(self.isOK), eof: \(self.isEOF))"
     }
 }
 

--- a/Sources/MySQLNIO/Utilities/CryptoUtils.swift
+++ b/Sources/MySQLNIO/Utilities/CryptoUtils.swift
@@ -15,11 +15,18 @@ func sha1(_ messages: ByteBuffer...) -> ByteBuffer {
 }
 
 func xor(_ a: ByteBuffer, _ b: ByteBuffer) -> ByteBuffer {
-    var a = a
-    var b = b
-    var output = ByteBufferAllocator().buffer(capacity: min(a.readableBytes, b.readableBytes))
-    while let a = a.readInteger(as: UInt8.self), let b = b.readInteger(as: UInt8.self) {
-        output.writeInteger(a ^ b)
+    assert(a.readableBytes == b.readableBytes)
+    var output = ByteBufferAllocator().buffer(capacity: a.readableBytes)
+    for i in 0..<a.readableBytes {
+        output.writeInteger(a.getInteger(at: i, as: UInt8.self)! ^ b.getInteger(at: i, as: UInt8.self)!)
+    }
+    return output
+}
+
+func xor_pattern(_ a: ByteBuffer, _ b: ByteBuffer) -> ByteBuffer {
+    var output = ByteBufferAllocator().buffer(capacity: a.readableBytes)
+    for i in 0..<a.readableBytes {
+        output.writeInteger(a.getInteger(at: i, as: UInt8.self)! ^ b.getInteger(at: i % b.readableBytes, as: UInt8.self)!)
     }
     return output
 }

--- a/Tests/MySQLNIOTests/MySQLNIOTests.swift
+++ b/Tests/MySQLNIOTests/MySQLNIOTests.swift
@@ -622,13 +622,13 @@ final class MySQLNIOTests: XCTestCase {
         XCTAssertEqual(time.date, nil)
     }
     
-    override func setUp() {
+    override func setUpWithError() throws {
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         XCTAssert(isLoggingConfigured)
     }
     
-    override func tearDown() {
-        try! self.group.syncShutdownGracefully()
+    override func tearDownWithError() throws {
+        try self.group.syncShutdownGracefully()
     }
 }
 

--- a/Tests/MySQLNIOTests/Utilities.swift
+++ b/Tests/MySQLNIOTests/Utilities.swift
@@ -3,17 +3,19 @@ import NIOSSL
 
 extension MySQLConnection {
     static func test(on eventLoop: EventLoop) -> EventLoopFuture<MySQLConnection> {
+        let addr: SocketAddress
         do {
-            return try self.connect(
-                to: .makeAddressResolvingHost(env("MYSQL_HOSTNAME") ?? "localhost", port: 3306),
-                username: "vapor_username",
-                database: "vapor_database",
-                password: "vapor_password",
-                tlsConfiguration: .forClient(certificateVerification: .none),
-                on: eventLoop
-            )
+            addr = try SocketAddress.makeAddressResolvingHost(env("MYSQL_HOSTNAME") ?? "localhost", port: 3306)
         } catch {
             return eventLoop.makeFailedFuture(error)
         }
+        return self.connect(
+            to: addr,
+            username: "vapor_username",
+            database: "vapor_database",
+            password: "vapor_password",
+            tlsConfiguration: .forClient(certificateVerification: .none),
+            on: eventLoop
+        )
     }
 }


### PR DESCRIPTION
Fixes the following failure modes:

- In tests, certain errors would crash instead of failing
- The `xor(_:_:)` utility did not correctly apply the operation to the entire buffer.
- Most protocol errors now throw a much more specific error.
- Trace logging is now more verbose during authentication.
- The `AuthSwitchRequest` packet (tagged with `0xfe` during the authentication phase, incorrectly treated as EOF before) is now correctly handled; this permits both the use of arbitrary auth plugins and the use of the "fast auth" mechanism.
- The `caching_sha2_password` handling would previously incorrectly treat the trailing `NUL` as part of the auth data.
- The `fast_auth_success` (`0x1 0x3`) packet during authentication is now correctly handled.
- When the `caching_sha2_password` plugin fails to authenticate on non-TLS connections, we now log a useful error message and throw a meaningful error. The framework is in place to implement this fully as soon as a usable implementation of the RSA public-key encrypt operation (with PEM armor and PKCS#1-OAEP padding support) is available.

This massively increases compatibility with all supported versions of MySQL and MariaDB and paves the way for further improvements.

Tagged `semver-minor` due to the new enumerators for the more specific errors.