### PR TITLE
Fix MYSQL_TIME data type

### DIFF
--- a/Sources/MySQLNIO/MySQLData.swift
+++ b/Sources/MySQLNIO/MySQLData.swift
@@ -117,8 +117,9 @@ public struct MySQLData: CustomStringConvertible, ExpressibleByStringLiteral, Ex
     
     public init(time: MySQLTime) {
         var buffer = ByteBufferAllocator().buffer(capacity: 11)
-        buffer.writeMySQLTime(time)
-        self.init(type: .datetime, format: .binary, buffer: buffer, isUnsigned: false)
+        var type: MySQLProtocol.DataType = .datetime
+        buffer.writeMySQLTime(time, as: &type)
+        self.init(type: type, format: .binary, buffer: buffer, isUnsigned: false)
     }
 
     private struct Wrapper: Encodable {

--- a/Sources/MySQLNIO/MySQLData.swift
+++ b/Sources/MySQLNIO/MySQLData.swift
@@ -116,7 +116,7 @@ public struct MySQLData: CustomStringConvertible, ExpressibleByStringLiteral, Ex
     }
     
     public init(time: MySQLTime) {
-        var buffer = ByteBufferAllocator().buffer(capacity: 11)
+        var buffer = ByteBufferAllocator().buffer(capacity: 12)
         var type: MySQLProtocol.DataType = .datetime
         buffer.writeMySQLTime(time, as: &type)
         self.init(type: type, format: .binary, buffer: buffer, isUnsigned: false)

--- a/Sources/MySQLNIO/MySQLTime.swift
+++ b/Sources/MySQLNIO/MySQLTime.swift
@@ -123,7 +123,7 @@ public struct MySQLTime: Equatable, MySQLDataConvertible {
 // MARK: Internal
 
 extension ByteBuffer {
-    mutating func writeMySQLTime(_ time: MySQLTime) {
+    mutating func writeMySQLTime(_ time: MySQLTime, as type: inout MySQLProtocol.DataType) {
         switch (
             time.year, time.month, time.day,
             time.hour, time.minute, time.second,
@@ -142,6 +142,7 @@ extension ByteBuffer {
             .none
         ):
             // date
+            type = .date
             self.writeInteger(year, endianness: .little, as: UInt16.self)
             self.writeInteger(numericCast(month), endianness: .little, as: UInt8.self)
             self.writeInteger(numericCast(day), endianness: .little, as: UInt8.self)
@@ -151,6 +152,7 @@ extension ByteBuffer {
             .none
         ):
             // date + time
+            type = .datetime
             self.writeInteger(year, endianness: .little, as: UInt16.self)
             self.writeInteger(numericCast(month), endianness: .little, as: UInt8.self)
             self.writeInteger(numericCast(day), endianness: .little, as: UInt8.self)
@@ -163,7 +165,8 @@ extension ByteBuffer {
             .none
         ):
             // time
-            self.writeBytes([0, 0, 0, 0])
+            type = .time
+            self.writeBytes([0, 0, 0, 0, 0])
             self.writeInteger(numericCast(hour), endianness: .little, as: UInt8.self)
             self.writeInteger(numericCast(minute), endianness: .little, as: UInt8.self)
             self.writeInteger(numericCast(second), endianness: .little, as: UInt8.self)
@@ -173,6 +176,7 @@ extension ByteBuffer {
             .some(let microsecond)
         ):
             // date + time + fractional seconds
+            type = .datetime
             self.writeInteger(year, endianness: .little, as: UInt16.self)
             self.writeInteger(numericCast(month), endianness: .little, as: UInt8.self)
             self.writeInteger(numericCast(day), endianness: .little, as: UInt8.self)
@@ -186,7 +190,8 @@ extension ByteBuffer {
             .some(let microsecond)
         ):
             // time + fractional seconds
-            self.writeBytes([0, 0, 0, 0])
+            type = .time
+            self.writeBytes([0, 0, 0, 0, 0])
             self.writeInteger(numericCast(hour), endianness: .little, as: UInt8.self)
             self.writeInteger(numericCast(minute), endianness: .little, as: UInt8.self)
             self.writeInteger(numericCast(second), endianness: .little, as: UInt8.self)

--- a/Tests/MySQLNIOTests/MySQLNIOTests.swift
+++ b/Tests/MySQLNIOTests/MySQLNIOTests.swift
@@ -357,6 +357,7 @@ final class MySQLNIOTests: XCTestCase {
     }
     
     func testPerformance_simpleSelects() throws {
+        try XCTSkipIf(env("PERFORMANCE_TESTS") == nil)
         let conn = try MySQLConnection.test(on: self.eventLoop).wait()
         defer { try! conn.close().wait() }
         for _ in 0..<1_000 {
@@ -365,6 +366,7 @@ final class MySQLNIOTests: XCTestCase {
     }
     
     func testPerformance_parseDatetime() throws {
+        try XCTSkipIf(env("PERFORMANCE_TESTS") == nil)
         let conn = try MySQLConnection.test(on: self.eventLoop).wait()
         defer { try! conn.close().wait() }
         
@@ -397,6 +399,7 @@ final class MySQLNIOTests: XCTestCase {
 
     // https://github.com/vapor/mysql-nio/issues/30
     func testPreparedStatement_maxOpen() throws {
+        try XCTSkipIf(env("PERFORMANCE_TESTS") == nil)
         let conn = try MySQLConnection.test(on: self.eventLoop).wait()
         defer { try! conn.close().wait() }
 


### PR DESCRIPTION
Fixes an issue causing `MYSQL_TIME` to use an incorrect data type when sending time or date only values (#54). 