### PR TITLE
Fix auth using empty password with MySQL 5.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,6 +105,12 @@ jobs:
           MYSQL_PASSWORD: vapor_password
           MYSQL_DATABASE: vapor_database
     steps:
+      - name: Workaround SPM incompatibility with old Git on CentOS 7
+        if: ${{ contains(matrix.runner, 'centos7') }}
+        run: |
+          yum install -y make libcurl-devel
+          git clone https://github.com/git/git -bv2.28.0 --depth 1 && cd git
+          make prefix=/usr -j all install NO_OPENSSL=1 NO_EXPAT=1 NO_TCLTK=1 NO_GETTEXT=1 NO_PERL=1
       - name: Check out code
         uses: actions/checkout@v2
       - name: Run tests with Thread Sanitizer

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
           MYSQL_USER: vapor_username
           MYSQL_PASSWORD: vapor_password
           MYSQL_DATABASE: vapor_database
-    container: swift:5.2-bionic
+    container: swift:5.2-focal
     strategy:
       fail-fast: false
       matrix:
@@ -66,19 +66,32 @@ jobs:
           # 5.2 Stable
           - swift:5.2-xenial
           - swift:5.2-bionic
+          - swift:5.2-focal
+          - swift:5.2-centos7
+          - swift:5.2-centos8
+          - swift:5.2-amazonlinux2
           # 5.2 Unstable
           - swiftlang/swift:nightly-5.2-xenial
           - swiftlang/swift:nightly-5.2-bionic
           # 5.3 Unstable
           - swiftlang/swift:nightly-5.3-xenial
           - swiftlang/swift:nightly-5.3-bionic
-          # Master Unsable
+          - swiftlang/swift:nightly-5.3-focal
+          - swiftlang/swift:nightly-5.3-centos7
+          - swiftlang/swift:nightly-5.3-centos8
+          - swiftlang/swift:nightly-5.3-amazonlinux2
+          # Main Unsable
           - swiftlang/swift:nightly-master-xenial
           - swiftlang/swift:nightly-master-bionic
           - swiftlang/swift:nightly-master-focal
+          - swiftlang/swift:nightly-master-centos7
           - swiftlang/swift:nightly-master-centos8
           - swiftlang/swift:nightly-master-amazonlinux2
         exclude:
+          - runner: swift:5.2-amazonlinux2
+            dbimage: mysql:8.0
+          - runner: swiftlang/swift:nightly-5.3-amazonlinux2
+            dbimage: mysql:8.0
           - runner: swiftlang/swift:nightly-master-amazonlinux2
             dbimage: mysql:8.0
     container: ${{ matrix.runner }}

--- a/Sources/MySQLNIO/Protocol/MySQLProtocol+COM_STMT_EXECUTE.swift
+++ b/Sources/MySQLNIO/Protocol/MySQLProtocol+COM_STMT_EXECUTE.swift
@@ -76,33 +76,13 @@ extension MySQLProtocol {
                     case .none: break
                     case .some(var buffer):
                         if value.type.encodingLength == nil {
-                            packet.payload.writeLengthEncoded(buffer.readableBytes)
+                            packet.payload.writeLengthEncodedSlice(&buffer)
+                        } else {
+                            packet.payload.writeBuffer(&buffer)
                         }
-                        packet.payload.writeBuffer(&buffer)
                     }
                 }
             }
-        }
-    }
-}
-
-extension ByteBuffer {
-    mutating func writeLengthEncoded(_ integer: Int) {
-        assert(integer >= 0, "Length must be positive")
-        switch integer {
-        case 0..<251:
-            self.writeInteger(numericCast(integer), as: UInt8.self)
-        case 251..<1<<16:
-            self.writeInteger(0xFC, as: UInt8.self)
-            self.writeInteger(numericCast(integer), endianness: .little, as: UInt16.self)
-        case 1<<16..<1<<24:
-            self.writeInteger(0xFD, as: UInt8.self)
-            self.writeInteger(numericCast(integer & 0xFF), as: UInt8.self)
-            self.writeInteger(numericCast(integer >> 8 & 0xFF), as: UInt8.self)
-            self.writeInteger(numericCast(integer >> 16 & 0xFF), as: UInt8.self)
-        default:
-            self.writeInteger(0xFE, as: UInt8.self)
-            self.writeInteger(numericCast(integer), endianness: .little, as: UInt64.self)
         }
     }
 }

--- a/Sources/MySQLNIO/Protocol/MySQLProtocol+CapabilityFlags.swift
+++ b/Sources/MySQLNIO/Protocol/MySQLProtocol+CapabilityFlags.swift
@@ -143,7 +143,10 @@ extension MySQLProtocol {
             .CLIENT_PLUGIN_AUTH,
             .CLIENT_SECURE_CONNECTION,
             .CLIENT_CONNECT_WITH_DB,
-            .CLIENT_DEPRECATE_EOF
+            .CLIENT_DEPRECATE_EOF,
+            .CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA,
+            .CLIENT_LONG_PASSWORD,
+            .CLIENT_TRANSACTIONS,
         ]
         
         /// All capabilities.

--- a/Sources/MySQLNIO/Protocol/MySQLProtocol+HandshakeResponse41.swift
+++ b/Sources/MySQLNIO/Protocol/MySQLProtocol+HandshakeResponse41.swift
@@ -64,12 +64,12 @@ extension MySQLPacket {
             packet.payload.writeInteger(maxPacketSize, endianness: .little)
             packet.payload.writeInteger(self.characterSet.rawValue, endianness: .little)
             /// string[23]     reserved (all [0])
-            packet.payload.writeBytes([
-                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
-            ])
+            packet.payload.writeBytes([UInt8](repeating: 0, count: 23))
             packet.payload.writeNullTerminatedString(self.username)
-            assert(self.capabilities.contains(.CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA) == false, "CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA not supported")
-            if self.capabilities.contains(.CLIENT_SECURE_CONNECTION) {
+            if self.capabilities.contains(.CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA) {
+                var responseCopy = authResponse
+                packet.payload.writeLengthEncodedSlice(&responseCopy)
+            } else if self.capabilities.contains(.CLIENT_SECURE_CONNECTION) {
                 assert(self.authResponse.readableBytes <= UInt8.max, "auth response too large")
                 packet.payload.writeInteger(UInt8(self.authResponse.readableBytes), endianness: .little)
                 var authResponseCopy = self.authResponse

--- a/Sources/MySQLNIO/Utilities/NIOUtils.swift
+++ b/Sources/MySQLNIO/Utilities/NIOUtils.swift
@@ -1,12 +1,7 @@
 extension ByteBuffer {
     mutating func readNullTerminatedString() -> String? {
         var copy = self
-        scan: while let byte = copy.readInteger(as: UInt8.self) {
-            switch byte {
-            case 0x00: break scan
-            default: break
-            }
-        }
+        while let byte = copy.readInteger(as: UInt8.self), byte != 0x00 { continue }
         defer { self.moveReaderIndex(forwardBy: 1) }
         return self.readString(length: (self.readableBytes - copy.readableBytes) - 1)
     }

--- a/Sources/MySQLNIO/Utilities/NIOUtils.swift
+++ b/Sources/MySQLNIO/Utilities/NIOUtils.swift
@@ -23,6 +23,29 @@ extension ByteBuffer {
         self.writeInteger(0, as: UInt8.self)
     }
     
+    mutating func writeLengthEncodedInteger(_ integer: UInt64) {
+        switch integer {
+        case 0..<251:
+            self.writeInteger(numericCast(integer), as: UInt8.self)
+        case 251..<1<<16:
+            self.writeInteger(0xFC, as: UInt8.self)
+            self.writeInteger(numericCast(integer), endianness: .little, as: UInt16.self)
+        case 1<<16..<1<<24:
+            self.writeInteger(0xFD, as: UInt8.self)
+            self.writeInteger(numericCast(integer & 0xFF), as: UInt8.self)
+            self.writeInteger(numericCast(integer >> 8 & 0xFF), as: UInt8.self)
+            self.writeInteger(numericCast(integer >> 16 & 0xFF), as: UInt8.self)
+        default:
+            self.writeInteger(0xFE, as: UInt8.self)
+            self.writeInteger(numericCast(integer), endianness: .little, as: UInt64.self)
+        }
+    }
+
+    mutating func writeLengthEncodedSlice(_ buffer: inout ByteBuffer) {
+        self.writeLengthEncodedInteger(numericCast(buffer.readableBytes))
+        self.writeBuffer(&buffer)
+    }
+    
     var readableString: String? {
         return self.getString(at: self.readerIndex, length: self.readableBytes)
     }

--- a/Tests/MySQLNIOTests/Utilities.swift
+++ b/Tests/MySQLNIOTests/Utilities.swift
@@ -5,15 +5,18 @@ extension MySQLConnection {
     static func test(on eventLoop: EventLoop) -> EventLoopFuture<MySQLConnection> {
         let addr: SocketAddress
         do {
-            addr = try SocketAddress.makeAddressResolvingHost(env("MYSQL_HOSTNAME") ?? "localhost", port: 3306)
+            addr = try SocketAddress.makeAddressResolvingHost(
+                env("MYSQL_HOSTNAME") ?? "localhost",
+                port: env("MYSQL_PORT").flatMap(Int.init) ?? 3306
+            )
         } catch {
             return eventLoop.makeFailedFuture(error)
         }
         return self.connect(
             to: addr,
-            username: "vapor_username",
-            database: "vapor_database",
-            password: "vapor_password",
+            username: env("MYSQL_USERNAME") ?? "vapor_username",
+            database: env("MYSQL_DATABASE") ?? "vapor_database",
+            password: env("MYSQL_PASSWORD") ?? "vapor_password",
             tlsConfiguration: .forClient(certificateVerification: .none),
             on: eventLoop
         )


### PR DESCRIPTION
The following changes have been made:

- When using the `mysql_native_password` auth plugin (or when authenticating with MySQL 5.7 in general), an empty password is now correctly treated as specifying no password at all. Fixes https://github.com/vapor/fluent-mysql-driver/issues/195.

- The `.CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA` capability, which improves and simplifies auth handling in some common cases, is now correctly supported and reported as such.

- The unit tests now support the `MYSQL_USERNAME`, `MYSQL_PASSWORD`, `MYSQL_DATABASE`, and `MYSQL_PORT` env vars.

- Small code cleanups.