### PR TITLE
Fix handling of null columns in TextResultSetRow

### DIFF
--- a/Sources/MySQLNIO/Protocol/MySQLProtocol+TextResultSetRow.swift
+++ b/Sources/MySQLNIO/Protocol/MySQLProtocol+TextResultSetRow.swift
@@ -25,6 +25,7 @@ extension MySQLProtocol {
                 switch header {
                 case 0xFB:
                     value = nil
+                    packet.payload.moveReaderIndex(forwardBy: 1)    // Consume the 0xFB byte
                 default:
                     guard let v = packet.payload.readLengthEncodedSlice() else {
                         fatalError()


### PR DESCRIPTION
When `TextResultSetRow` encountered a null column, it did not increment the buffer index, and so it would repeatedly read `NULL` into every remaining column. This patch fixes the issue and adds regression tests (#57).