### PR TITLE
Clean up the ByteBuffer utility methods

### DIFF
--- a/Sources/MySQLNIO/Protocol/MySQLProtocol+HandshakeV10.swift
+++ b/Sources/MySQLNIO/Protocol/MySQLProtocol+HandshakeV10.swift
@@ -103,13 +103,13 @@ extension MySQLProtocol {
                 guard let reserved1 = packet.payload.readSlice(length: 6) else {
                     throw Error.missingReserved
                 }
-                assert(reserved1.isZeroes, "invalid reserve 1 \(reserved1)")
+                assert(reserved1.readableBytesView.allSatisfy { $0 == 0 }, "invalid reserve 1 \(reserved1)")
                 if capabilities.contains(.CLIENT_LONG_PASSWORD) {
                     /// string[4]     reserved (all [00])
                     guard let reserved2 = packet.payload.readSlice(length: 4) else {
                         throw Error.missingReserved
                     }
-                    assert(reserved2.isZeroes, "invalid reserve 2: \(reserved2)")
+                    assert(reserved2.readableBytesView.allSatisfy { $0 == 0 }, "invalid reserve 2: \(reserved2)")
                 } else {
                     /// Capabilities 3rd part. MariaDB specific flags.
                     /// MariaDB Initial Handshake Packet specific flags


### PR DESCRIPTION
- Replace the `readNullTerminatedString()` implementation with the much more efficient version used by PostgresNIO.
- Made `writeNullTerminatedString()`, `writeLengthEncodedInteger()`, and `writeLengthEncodedSlice()` return the number of bytes written, to match `ByteBuffer` method conventions.
- Simplified `[read|write]LengthEncodedInteger()`, might be slightly faster but probably not enough to notice.
- Remove a couple of unused utility methods altogether.
