### PR TITLE
Improve error handling

### DIFF
--- a/Sources/MySQLNIO/MySQLConnection.swift
+++ b/Sources/MySQLNIO/MySQLConnection.swift
@@ -71,7 +71,12 @@ public final class MySQLConnection: MySQLDatabase {
     }
     
     public func send(_ command: MySQLCommand, logger: Logger) -> EventLoopFuture<Void> {
+        guard self.channel.isActive else {
+            return self.channel.eventLoop.makeFailedFuture(MySQLError.closed)
+        }
+
         let promise = self.eventLoop.makePromise(of: Void.self)
+        
         let c = MySQLCommandContext(
             handler: command,
             promise: promise

--- a/Sources/MySQLNIO/MySQLError.swift
+++ b/Sources/MySQLNIO/MySQLError.swift
@@ -15,6 +15,9 @@ public enum MySQLError: Error, CustomStringConvertible, LocalizedError {
     /// A uniqueness constraint was violated. Associated value is message from server with details.
     case duplicateEntry(String)
     
+    /// A syntax error occurred in a query. Associated value is message from server with details.
+    case invalidSyntax(String)
+    
     public var message: String {
         switch self {
         case .secureConnectionRequired:
@@ -39,6 +42,8 @@ public enum MySQLError: Error, CustomStringConvertible, LocalizedError {
             return "Connection closed."
         case .duplicateEntry(let message):
             return "Duplicate entry: \(message)"
+        case .invalidSyntax(let message):
+            return "Invalid syntax: \(message)"
         }
     }
     

--- a/Sources/MySQLNIO/MySQLQueryCommand.swift
+++ b/Sources/MySQLNIO/MySQLQueryCommand.swift
@@ -92,6 +92,8 @@ private final class MySQLQueryCommand: MySQLCommand {
             switch errorPacket.errorCode {
             case .DUP_ENTRY:
                 error = MySQLError.duplicateEntry(errorPacket.errorMessage)
+            case .PARSE_ERROR:
+                error = MySQLError.invalidSyntax(errorPacket.errorMessage)
             default:
                 error = MySQLError.server(errorPacket)
             }


### PR DESCRIPTION
- "Connection closed" errors are now correctly reported when trying to issue queries on closed connections, instead of throwing various NIO errors.
- Query syntax errors are now explicitly reported.
- Unique constraint violation errors are now more consistently reported.

`semver-minor` due to adding a new case on `MySQLError`.