### PR TITLE
Fix crash when parsing timestamps with microsecond text

### DIFF
--- a/Sources/MySQLNIO/MySQLTime.swift
+++ b/Sources/MySQLNIO/MySQLTime.swift
@@ -82,11 +82,16 @@ public struct MySQLTime: Equatable, MySQLDataConvertible {
               let day = UInt16(parts[2]),
               let hour = UInt16(parts[3]),
               let minute = UInt16(parts[4]),
-              let second = UInt16(parts[5])
+              let second = Double(parts[5])
         else {
             return nil
         }
-        self.init(year: year, month: month, day: day, hour: hour, minute: minute, second: second)
+        
+        let fullSecond = UInt32((second * 1_000_000).rounded())
+        let integer = UInt16(fullSecond / 1_000_000)
+        let real = fullSecond % 1_000_000
+        
+        self.init(year: year, month: month, day: day, hour: hour, minute: minute, second: integer, microsecond: real)
     }
     
     /// See ``MySQLDataConvertible/init(mysqlData:)``.


### PR DESCRIPTION
Crash occurred even parsing logic enhanced by #72.

When you get rows from the simple query with `TIMESTAMP` column like this.

| id | ... | created_at |
|-|-|-|
| 1 | ... | 1970–01–01 00:00:01.000000 |

Application crashed at `MySQLData.swift:459` due to forced unwrapping of `time` with a value of `nil`.
```swift
457:            ...
458:            case .datetime, .timestamp:
450:                return (self.time!.date ?? Date(timeIntervalSince1970: 0)).description
```

If we follow the logic of the `MySQLTime` conversion of `TIMESTAMP` text to `MySQLTime`, we can find that point of crash.
```swift
public init?(_ string: String) {
    ...    
    guard parts.count >= 6,
          let year = UInt16(parts[0]),
          let month = UInt16(parts[1]),
          let day = UInt16(parts[2]),
          let hour = UInt16(parts[3]),
          let minute = UInt16(parts[4]),
          let second = UInt16(parts[5]) // <- `parts[5]` is "01.000000" actually. Conversion to `UInt16` fails because of microseconds.
    else {
        return nil
    }
    ...
}
```

So we added code to parse the real number text correctly.