### PR TITLE
Widen pin on swift-crypto dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-algorithms.git", from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "4.0.0"),
+        .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "5.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.14.0"),


### PR DESCRIPTION
**These changes are now available in [1.9.1](https://github.com/vapor/mysql-nio/releases/tag/1.9.1)**


### What?
Widens the supported `swift-crypto` range to include the 4+ series of releases.

### Why?
1) Using `swift-crypto` 4.2.0 doesn't seem to impact the building or tests
2) Allows for newer libraries that need `swift-crypto` 4+ tags to still use this library
3) This combined with `mysql-kit` widening its pin on `swift-crypto` would allow `vapor` users depending on `fluent-mysql-driver` to use the latest, and safest, `swift-crypto` versions.