### PR TITLE
Fix race condition: install handlers via channelInitializer (#121)

### DIFF
--- a/Sources/MySQLNIO/MySQLConnection.swift
+++ b/Sources/MySQLNIO/MySQLConnection.swift
@@ -14,41 +14,41 @@ public final class MySQLConnection: MySQLDatabase, Sendable {
         logger: Logger = .init(label: "codes.vapor.mysql"),
         on eventLoop: any EventLoop
     ) -> EventLoopFuture<MySQLConnection> {
+        let sequence = MySQLPacketSequence()
+        let done = eventLoop.makePromise(of: Void.self)
+
         let bootstrap = ClientBootstrap(group: eventLoop)
             .channelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
-        
-        logger.debug("Opening new connection to \(socketAddress)")
-        
-        return bootstrap.connect(to: socketAddress).flatMap { channel in
-            let sequence = MySQLPacketSequence()
-            let done = channel.eventLoop.makePromise(of: Void.self)
-            done.futureResult.whenFailure { _ in
-                channel.close(mode: .all, promise: nil)
-            }
-            do {
-                try channel.pipeline.syncOperations.addHandlers([
-                    ByteToMessageHandler(MySQLPacketDecoder(
-                        sequence: sequence,
-                        logger: logger
-                    )),
-                    MessageToByteHandler(MySQLPacketEncoder(
-                        sequence: sequence,
-                        logger: logger
-                    )),
-                    MySQLConnectionHandler(logger: logger, state: .handshake(.init(
-                        username: username,
-                        database: database,
-                        password: password,
-                        tlsConfiguration: tlsConfiguration,
-                        serverHostname: serverHostname,
-                        done: done
-                    )), sequence: sequence),
-                    ErrorHandler()
-                ], position: .last)
-            } catch {
-                return channel.eventLoop.makeFailedFuture(error)
+            .channelInitializer { channel in
+                done.futureResult.whenFailure { _ in
+                    channel.close(mode: .all, promise: nil)
+                }
+                return channel.eventLoop.makeCompletedFuture {
+                    try channel.pipeline.syncOperations.addHandlers([
+                        ByteToMessageHandler(MySQLPacketDecoder(
+                            sequence: sequence,
+                            logger: logger
+                        )),
+                        MessageToByteHandler(MySQLPacketEncoder(
+                            sequence: sequence,
+                            logger: logger
+                        )),
+                        MySQLConnectionHandler(logger: logger, state: .handshake(.init(
+                            username: username,
+                            database: database,
+                            password: password,
+                            tlsConfiguration: tlsConfiguration,
+                            serverHostname: serverHostname,
+                            done: done
+                        )), sequence: sequence),
+                        ErrorHandler()
+                    ], position: .last)
+                }
             }
 
+        logger.debug("Opening new connection to \(socketAddress)")
+
+        return bootstrap.connect(to: socketAddress).flatMap { channel in
             return done.futureResult.map { MySQLConnection(channel: channel, logger: logger) }
         }
     }


### PR DESCRIPTION
NOTE (from @mrdekk): The investigation was done by my AI agent, and here it's resume about fix (it work for me). I add agent's full report on problem discovery and fix with html file (attached to this pull request)

## Problem

The MySQL server greeting can arrive and be read from the socket before MySQLConnectionHandler is added to the NIO channel pipeline. This causes the greeting to be silently dropped — the handshake never completes and the server closes the connection after connect_timeout (typically 10s).

This manifests as intermittent `IOError: Connection reset by peer` on Linux, especially on repeated connections to localhost. The first connection after a server restart often works (slow greeting), but subsequent ones fail (fast greeting arrives before handlers are in place).

## Root Cause

Channel handlers were installed in a `.flatMap` callback after `bootstrap.connect()` resolves. In SwiftNIO's ClientBootstrap, the connection lifecycle is:

  1. applyChannelOptions (autoRead = true)
  2. channelInitializer ← not used
  3. register() + connect()
  4. becomeActive0() → fireChannelActive → readIfNeeded0 (autoRead starts)
  5. Connect promise resolves → .flatMap fires → handlers added (too late)

On Linux (epoll), a localhost TCP connect completes instantly. The MySQL greeting can arrive and be read in the same event loop cycle, before the .flatMap callback executes. On macOS (kqueue), the timing is different and the race does not manifest in practice.

## Fix

Install handlers via `.channelInitializer` instead of `.flatMap`. channelInitializer is called synchronously on the event loop BEFORE register(), connect(), and autoRead — guaranteeing handlers are in the pipeline before any I/O occurs.

`MySQLPacketSequence` and the `done` promise are created before the bootstrap (they don't require a Channel) and captured by the closure.

## Verification

Confirmed via strace on Linux (Ubuntu 22.04, MariaDB 11.4, epoll):
- Before: `read(fd, greeting) = 95` → `epoll_wait` (no write) → timeout
- After:  `read(fd, greeting) = 95` → `write(fd, response)` → success

10+ consecutive runs on Linux without failures.

[mysql-nio-linux-race-condition-report.en.html](https://github.com/user-attachments/files/27100279/mysql-nio-linux-race-condition-report.en.html)
