### PR TITLE
Improve error handling

### DIFF
--- a/Sources/MySQLNIO/Connection/MySQLChannelHandler+stateMachine.swift
+++ b/Sources/MySQLNIO/Connection/MySQLChannelHandler+stateMachine.swift
@@ -221,7 +221,7 @@ extension MySQLChannelHandler {
         }
 
         @usableFromInline
-        mutating func receivedResponse(packet: inout ByteBuffer) -> ReceivedResponseAction {
+        mutating func receivedResponse(packet: inout ByteBuffer) throws -> ReceivedResponseAction {
             switch consume self.state {
             case .startup:
                 preconditionFailure("Cannot receive packet when in startup state")
@@ -262,14 +262,24 @@ extension MySQLChannelHandler {
                         initialHandshake.authenticationPluginName,
                         capabilities: clientCapabilities
                     )
-                    guard
-                        let authResponse = authMethod.processData(
-                            initialHandshake.authenticationPluginData,
-                            password: state.configuration.password,
-                            connectionIsSecure: connectionIsSecure
-                        )
-                    else {
-                        preconditionFailure("The auth response cannot be nil at this stage.")
+                    let authResponse: ByteBuffer
+                    do {
+                        guard
+                            let response = try authMethod.processData(
+                                initialHandshake.authenticationPluginData,
+                                password: state.configuration.password,
+                                connectionIsSecure: connectionIsSecure
+                            )
+                        else {
+                            preconditionFailure("The auth response cannot be nil at this stage.")
+                            // It cannot be nil because no authentication method currently returns nil at the first step of the authentication process,
+                            // not because the server could be returning invalid data.
+                            // If a method is added that returns nil, this precondition failure should be replaced with proper handling of that case.
+                        }
+                        authResponse = response
+                    } catch {
+                        self = .closed(error)
+                        return .failPromise(state.connectPromise, error)
                     }
 
                     self = .awaitingAuthReply(
@@ -359,21 +369,33 @@ extension MySQLChannelHandler {
                     }
                     // TODO: mysql_native_password in authentication switch in MariaDB doesn't work for root user with empty password
                     state.authMethod = AuthenticationMethods.fromName(authSwitchRequest.authenticationPluginName, capabilities: nil)
-                    let responsePacket = state.authMethod.processData(
-                        authSwitchRequest.authenticationPluginData,
-                        password: state.password,
-                        connectionIsSecure: state.capabilities.contains(.ssl)
-                    )
+                    let responsePacket: ByteBuffer?
+                    do {
+                        responsePacket = try state.authMethod.processData(
+                            authSwitchRequest.authenticationPluginData,
+                            password: state.password,
+                            connectionIsSecure: state.capabilities.contains(.ssl)
+                        )
+                    } catch {
+                        self = .closed(error)
+                        return .failPromise(state.connectPromise, error)
+                    }
                     self = .awaitingAuthReply(state)
                     return .authRespond(responsePacket)
                 } else if packet.mySQLHeaderFlag == 0x02 {
                     fatalError("TODO: Multi Factor Authentication is not yet supported")
                 } else {
-                    let responsePacket = state.authMethod.processData(
-                        packet,
-                        password: state.password,
-                        connectionIsSecure: state.capabilities.contains(.ssl)
-                    )
+                    let responsePacket: ByteBuffer?
+                    do {
+                        responsePacket = try state.authMethod.processData(
+                            packet,
+                            password: state.password,
+                            connectionIsSecure: state.capabilities.contains(.ssl)
+                        )
+                    } catch {
+                        self = .closed(error)
+                        return .failPromise(state.connectPromise, error)
+                    }
                     self = .awaitingAuthReply(state)
                     return .authRespond(responsePacket)
                 }

--- a/Sources/MySQLNIO/Connection/MySQLChannelHandler.swift
+++ b/Sources/MySQLNIO/Connection/MySQLChannelHandler.swift
@@ -214,7 +214,7 @@ final class MySQLChannelHandler: ChannelDuplexHandler {
         self.logger.trace("Received MySQL packet")
 
         var packet = packet
-        switch self.stateMachine.receivedResponse(packet: &packet) {
+        switch try self.stateMachine.receivedResponse(packet: &packet) {
         case .closeWithError(let error):
             throw error
         case .handshakeRespond(let handshakeResponse, let sslRequest, let statusFlags):

--- a/Sources/MySQLNIO/Protocol/Authentication Methods/AuthenticationMethod.swift
+++ b/Sources/MySQLNIO/Protocol/Authentication Methods/AuthenticationMethod.swift
@@ -3,7 +3,7 @@ public import NIOCore
 @usableFromInline
 protocol AuthenticationMethod: ~Copyable {
     static var name: String { get }
-    mutating func processData(_ data: ByteBuffer, password: String?, connectionIsSecure: Bool) -> ByteBuffer?
+    mutating func processData(_ data: ByteBuffer, password: String?, connectionIsSecure: Bool) throws -> ByteBuffer?
 }
 
 enum AuthenticationMethods {
@@ -21,7 +21,7 @@ enum AuthenticationMethods {
                 {
                     MySQLNativePassword()
                 } else {
-                    preconditionFailure("Old Password Authentication is not supported.")
+                    fatalError("Old Password Authentication is not supported.")
                 }
             } else {
                 preconditionFailure("capabilities can be nil only if the authentication plugin name is provided, but it was not")

--- a/Sources/MySQLNIO/Protocol/Authentication Methods/CachingSHA2Password.swift
+++ b/Sources/MySQLNIO/Protocol/Authentication Methods/CachingSHA2Password.swift
@@ -6,8 +6,8 @@ import _CryptoExtras
 struct CachingSHA2Password: AuthenticationMethod, ~Copyable {
     static let name = "caching_sha2_password"
     var stateMachine = StateMachine()
-    mutating func processData(_ data: ByteBuffer, password: String?, connectionIsSecure: Bool) -> ByteBuffer? {
-        self.stateMachine.processData(data, password: password, connectionIsSecure: connectionIsSecure)
+    mutating func processData(_ data: ByteBuffer, password: String?, connectionIsSecure: Bool) throws -> ByteBuffer? {
+        try self.stateMachine.processData(data, password: password, connectionIsSecure: connectionIsSecure)
     }
 }
 
@@ -37,19 +37,23 @@ extension CachingSHA2Password {
             self.state = state
         }
 
-        mutating func processData(_ data: ByteBuffer, password: String?, connectionIsSecure: Bool) -> ByteBuffer? {
+        enum Error: Swift.Error {
+            case invalidSeed
+            case invalidResponse
+            case invalidPublicKey
+        }
+
+        mutating func processData(_ data: ByteBuffer, password: String?, connectionIsSecure: Bool) throws -> ByteBuffer? {
             switch consume self.state {
             case .uninitialized:
                 self = .fastAuthentication(nonce: connectionIsSecure ? .init() : data)
                 if let password {
-                    guard data.readableBytes == 20 else { preconditionFailure("Invalid seed") }
+                    guard data.readableBytes == 20 else { throw Error.invalidSeed }
                     let passwordHash = SHA256.hash(data: Array(password.utf8))
                     let seedHash = SHA256.hash(data: Array(chain(SHA256.hash(data: Array(passwordHash)), data.readableBytesView)))
                     return ByteBuffer(bytes: zip(passwordHash, seedHash).map(^))
                 } else {
-                    var emptyPassword = ByteBuffer()
-                    emptyPassword.writeNullTerminatedString("")
-                    return emptyPassword
+                    return ByteBuffer(bytes: [0x00])
                 }
             case .fastAuthentication(let nonce):
                 guard data.readableBytes == 2,
@@ -57,7 +61,8 @@ extension CachingSHA2Password {
                     let resultByte = data.getInteger(at: data.readerIndex + 1, as: UInt8.self),
                     let result = FastAuthenticationResult(rawValue: resultByte)
                 else {
-                    preconditionFailure("Invalid caching_sha2_password response to fast authentication")
+                    self = .end
+                    throw Error.invalidResponse
                 }
                 switch result {
                 case .success:
@@ -79,10 +84,10 @@ extension CachingSHA2Password {
                     let pemString = data.getString(at: data.readerIndex + 1, length: data.readableBytes - 1),
                     let key = try? _RSA.Encryption.PublicKey(pemRepresentation: pemString)
                 else {
-                    preconditionFailure("Invalid RSA public key from server")
+                    throw Error.invalidPublicKey
                 }
                 let saltedPassword = Array(zip(chain((password ?? "").utf8, [0]), nonce.readableBytesView.cycled()).map(^))
-                return ByteBuffer(bytes: try! key.encrypt(saltedPassword, padding: .PKCS1_OAEP))  // TODO: handle errors
+                return ByteBuffer(bytes: try key.encrypt(saltedPassword, padding: .PKCS1_OAEP))
             case .end:
                 preconditionFailure("Received data after authentication completed")
             }

--- a/Sources/MySQLNIO/Protocol/Authentication Methods/MySQLNativePassword.swift
+++ b/Sources/MySQLNIO/Protocol/Authentication Methods/MySQLNativePassword.swift
@@ -5,8 +5,8 @@ import NIOCore
 struct MySQLNativePassword: AuthenticationMethod, ~Copyable {
     static let name = "mysql_native_password"
     var stateMachine = StateMachine()
-    mutating func processData(_ data: ByteBuffer, password: String?, connectionIsSecure _: Bool) -> ByteBuffer? {
-        self.stateMachine.processData(data, password: password)
+    mutating func processData(_ data: ByteBuffer, password: String?, connectionIsSecure _: Bool) throws -> ByteBuffer? {
+        try self.stateMachine.processData(data, password: password)
     }
 }
 
@@ -29,11 +29,15 @@ extension MySQLNativePassword {
             self.state = state
         }
 
-        mutating func processData(_ data: ByteBuffer, password: String?) -> ByteBuffer {
+        enum Error: Swift.Error {
+            case invalidSeed
+        }
+
+        mutating func processData(_ data: ByteBuffer, password: String?) throws -> ByteBuffer {
             switch consume self.state {
             case .uninitialized:
                 self = .end
-                guard data.readableBytes == 20 else { preconditionFailure("Invalid seed") }
+                guard data.readableBytes == 20 else { throw Error.invalidSeed }
                 let passwordHash = Insecure.SHA1.hash(data: Array((password ?? "").utf8))
                 let seedHash = Insecure.SHA1.hash(data: Array(chain(data.readableBytesView, Insecure.SHA1.hash(data: Array(passwordHash)))))
                 return ByteBuffer(bytes: zip(passwordHash, seedHash).map(^))


### PR DESCRIPTION
I have reviewed all the `fatalError` and `preconditionFailure` statements in the code.

`fatalError` statements remain only in cases where the server’s response is valid, but we do not currently support it. The intention is to implement the missing code and remove the `fatalError`.

The `preconditionFailure` statements remain only in cases where the condition is not possible, not because we expected a different response from the server, but because of the way our code is written and the state machine works, that state or returned value is logically only possible in the event of a programming error. In that case, if we encounter a `preconditionFailure`, it is a clear warning sign that we have made a mistake and need to review the code.