### PR TITLE
Fix empty-password authentication with caching_sha2_password

### DIFF
--- a/Sources/MySQLNIO/MySQLConnectionHandler.swift
+++ b/Sources/MySQLNIO/MySQLConnectionHandler.swift
@@ -159,9 +159,14 @@ final class MySQLConnectionHandler: ChannelDuplexHandler {
         switch authPluginName {
         case "caching_sha2_password":
             let seed = authPluginData
-            hash = xor(sha256(password), sha256(sha256(sha256(password)), seed))
             saveSeed = seed.getBytes(at: 0, length: seed.readableBytes) ?? []
-            self.logger.trace("Generated scrambled hash for caching_sha2_password")
+            if let passwordValue = passwordInput, !passwordValue.isEmpty {
+                hash = xor(sha256(password), sha256(sha256(sha256(password)), seed))
+                self.logger.trace("Generated scrambled hash for caching_sha2_password")
+            } else {
+                hash = .init()
+                self.logger.trace("Generated empty response for caching_sha2_password with empty password input")
+            }
         case "mysql_native_password":
             if let passwordValue = passwordInput, !passwordValue.isEmpty {
                 var copy = authPluginData

--- a/Tests/MySQLNIOTests/MySQLNIOTests.swift
+++ b/Tests/MySQLNIOTests/MySQLNIOTests.swift
@@ -30,6 +30,42 @@ struct MySQLNIOTests {
     init() {
         #expect(isLoggingConfigured)
     }
+
+    @Test(arguments: [nil, ""] as [String?])
+    func cachingSHA2PasswordWithoutPasswordSendsEmptyAuthResponse(password: String?) throws {
+        #expect(try cachingSHA2AuthResponse(password: password).readableBytes == 0)
+    }
+
+    @Test
+    func cachingSHA2PasswordWithPasswordStillSendsScrambledAuthResponse() throws {
+        #expect(try cachingSHA2AuthResponse(password: "secret").readableBytes == 32)
+    }
+
+    private func cachingSHA2AuthResponse(password: String?) throws -> ByteBuffer {
+        let eventLoop = MultiThreadedEventLoopGroup.singleton.next()
+        let done = eventLoop.makePromise(of: Void.self)
+        defer { done.succeed(()) }
+        let handler = MySQLConnectionHandler(
+            logger: .init(label: "codes.vapor.mysql.tests"),
+            state: .handshake(.init(
+                username: "root",
+                database: "",
+                password: password,
+                tlsConfiguration: nil,
+                serverHostname: nil,
+                done: done
+            )),
+            sequence: .init()
+        )
+        let response = try handler.doInitialAuthPluginHandling(
+            authPluginName: "caching_sha2_password",
+            isTLS: false,
+            passwordInput: password,
+            authPluginData: .init(bytes: Array(0..<20)),
+            done: done
+        )
+        return response
+    }
     
     @Test
     func decodingSumOfIntsWithNoRows() async throws {


### PR DESCRIPTION
## Summary

Encode an empty authentication response when `caching_sha2_password` is selected and the caller supplies no password (`nil`) or an empty password.

This mirrors the existing `mysql_native_password` empty-password handling and leaves the nonempty SHA-256 scramble path unchanged.

## Problem

`doInitialAuthPluginHandling` currently always computes a SHA-256 scramble for `caching_sha2_password`. For an absent or empty password, that produces a nonempty 32-byte response derived from the empty string.

A MySQL account configured with an empty password expects an empty initial authentication response. The current response is therefore rejected even when the server account is intentionally passwordless.

## Change

- Return an empty authentication response when `passwordInput` is `nil` or empty.
- Retain the server seed in authentication state so a subsequent full-authentication exchange remains well-defined.
- Preserve the existing scramble calculation for nonempty passwords.

No server authorization logic changes; the server remains authoritative.

## Validation

- Focused Swift tests pass for `nil`, empty, and nonempty password inputs.
- Empty inputs produce a zero-byte initial response.
- A nonempty input retains the existing 32-byte response.
- A live connection through an unchanged GlassDBKit adapter succeeded against MySQL 9.7.1 with TLS disabled and a passwordless `caching_sha2_password` account.
- The same live path with mysql-nio 1.9.1 reproduced `Access denied ... (using password: YES)`.

The full upstream integration suite was not run because its default environment requires a separately provisioned MySQL test database.
