### PR TITLE
Fix caching_sha2 nonce parsing for long passwords

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,8 @@ jobs:
 
   linux-insecure-test:
     if: ${{ !(github.event.pull_request.draft || false) }}
+    env:
+      MYSQL_PASSWORD: 'test_password_longer_than_twenty_bytes'
     strategy:
       fail-fast: false
       matrix:
@@ -53,7 +55,7 @@ jobs:
       mysql-a:
         image: ${{ matrix.dbimage }}
         volumes: [ 'mysqlshare:/var/run/mysqld' ]
-        env: { MYSQL_ALLOW_EMPTY_PASSWORD: true, MYSQL_USER: test_username, MYSQL_PASSWORD: test_password, MYSQL_DATABASE: test_database }
+        env: { MYSQL_ALLOW_EMPTY_PASSWORD: true, MYSQL_USER: test_username, MYSQL_PASSWORD: test_password_longer_than_twenty_bytes, MYSQL_DATABASE: test_database }
     steps:
       - name: Force MySQL server to disallow TLS
         shell: bash

--- a/Sources/MySQLNIO/Protocol/MySQLProtocol+HandshakeV10.swift
+++ b/Sources/MySQLNIO/Protocol/MySQLProtocol+HandshakeV10.swift
@@ -128,6 +128,18 @@ extension MySQLProtocol {
                     guard var authPluginDataPart2 = packet.payload.readSlice(length: authPluginDataPart2Length) else {
                         throw Error.missingAuthPluginData
                     }
+                    if capabilities.contains(.CLIENT_PLUGIN_AUTH),
+                       authPluginDataPart2.readableBytes > 0,
+                       authPluginDataPart2.getInteger(
+                           at: authPluginDataPart2.writerIndex - 1,
+                           as: UInt8.self
+                       ) == 0 {
+                        // The wire field is at least 13 bytes: 12 bytes of
+                        // plugin data followed by a NUL terminator. The
+                        // terminator separates the data from the plugin name;
+                        // it is not part of the authentication nonce.
+                        authPluginDataPart2.moveWriterIndex(to: authPluginDataPart2.writerIndex - 1)
+                    }
                     authPluginData = authPluginDataPart1
                     authPluginData.writeBuffer(&authPluginDataPart2)
                     if !capabilities.contains(.CLIENT_PLUGIN_AUTH) {

--- a/Tests/MySQLNIOTests/MySQLNIOTests.swift
+++ b/Tests/MySQLNIOTests/MySQLNIOTests.swift
@@ -30,6 +30,50 @@ struct MySQLNIOTests {
     init() {
         #expect(isLoggingConfigured)
     }
+
+    @Test
+    func handshakeExcludesAuthPluginDataTerminatorFromNonce() throws {
+        // Captured from MySQL 8.4.10. The packet advertises 21 bytes of auth
+        // plugin data on the wire: a 20-byte nonce plus its NUL terminator.
+        let packetHex = """
+            5b 00 00 00 0a 38 2e 34 2e 31 30 2d 30 75 62 75
+            6e 74 75 30 2e 32 35 2e 31 30 2e 31 00 ab 5e 09
+            00 46 73 0c 10 45 74 33 18 00 ff ff ff 02 00 ff
+            df 15 00 00 00 00 00 00 00 00 00 00 20 29 23 43
+            71 7b 6c 49 62 7d 7e 15 00 63 61 63 68 69 6e 67
+            5f 73 68 61 32 5f 70 61 73 73 77 6f 72 64 00
+            """
+        let bytes = packetHex.split(whereSeparator: \.isWhitespace).compactMap {
+            UInt8($0, radix: 16)
+        }
+        var packet = MySQLPacket(payload: .init(bytes: bytes.dropFirst(4)))
+
+        let handshake = try packet.decode(MySQLProtocol.HandshakeV10.self, capabilities: [])
+
+        #expect(handshake.authPluginName == "caching_sha2_password")
+        #expect(handshake.authPluginData.readableBytes == 20)
+        #expect(
+            Array(handshake.authPluginData.readableBytesView) == [
+                0x46, 0x73, 0x0c, 0x10, 0x45, 0x74, 0x33, 0x18,
+                0x20, 0x29, 0x23, 0x43, 0x71, 0x7b, 0x6c, 0x49,
+                0x62, 0x7d, 0x7e, 0x15,
+            ]
+        )
+        #expect(packet.payload.readableBytes == 0)
+    }
+
+    @Test
+    func longPasswordAuthenticatesAcrossFreshConnections() async throws {
+        // The insecure MySQL CI job sets a password longer than the 20-byte
+        // caching_sha2_password nonce. Two fresh connections exercise both
+        // the full-authentication and cached fast-authentication paths.
+        for _ in 0..<2 {
+            let connection = try await MySQLConnection.test()
+            let rows = try await connection.simpleQuery("SELECT 1 AS value").get()
+            #expect(rows.first?.column("value")?.int == 1)
+            try await connection.close().get()
+        }
+    }
     
     @Test
     func decodingSumOfIntsWithNoRows() async throws {


### PR DESCRIPTION
## Summary
- exclude the trailing NUL terminator from HandshakeV10 authentication plugin data
- add regression coverage using a captured MySQL 8.4.10 handshake packet
- exercise full and cached authentication with a password longer than the 20-byte nonce

## Why
MySQL documents caching_sha2_password nonces as 20 bytes. HandshakeV10 carries the second nonce segment in a 13-byte field where the final byte is the NUL separator before the plugin name. Including that separator in the saved seed corrupts RSA full-authentication for passwords longer than 20 bytes.

## Validation
- focused captured-packet test passes
- focused two-connection live test passes against MySQL 8.4.10 with TLS identity disabled and a 38-character password
- full mysql-nio suite passes against that server (45 tests total across XCTest and Swift Testing)