### PR TITLE
Implement `MySQLRow`

### DIFF
--- a/Sources/MySQLNIO/Connection/MySQLChannelHandler+stateMachine.swift
+++ b/Sources/MySQLNIO/Connection/MySQLChannelHandler+stateMachine.swift
@@ -907,6 +907,24 @@ extension MySQLChannelHandler.StateMachine {
             }
             switch consume self.state {
             case .awaitingResultsetStart:
+                if packet.isOKPacket(capabilities: self.capabilities) {
+                    guard let okPacket = try? OKPacket(from: &packet, capabilities: self.capabilities) else {
+                        let error = MySQLClientError.invalidPacket("Received an invalid OK Packet")
+                        self = .done(result: error, capabilities: self.capabilities)
+                        return .error(error)
+                    }
+                    if okPacket.serverStatus.contains(.serverMoreResultsExists) {
+                        self = .awaitingResultsetStart(capabilities: self.capabilities)
+                        return .moreResultsExists
+                    }
+                    self = .done(result: nil, capabilities: self.capabilities)
+                    return .resultsetEnd
+                }
+                guard let columnCount = packet.readEncodedInteger(as: UInt64.self, strategy: .mySQL) else {
+                    let error = MySQLClientError.invalidPacket("Received an invalid Result Set Header Packet")
+                    self = .done(result: error, capabilities: self.capabilities)
+                    return .error(error)
+                }
                 var metadataFollows = false
                 if self.capabilities.metadataFlagAvailable {
                     guard let metadataFollowsFlag = packet.readInteger(as: UInt8.self) else {
@@ -915,11 +933,6 @@ extension MySQLChannelHandler.StateMachine {
                         return .error(error)
                     }
                     metadataFollows = metadataFollowsFlag == 1
-                }
-                guard let columnCount = packet.readEncodedInteger(as: UInt64.self, strategy: .mySQL) else {
-                    let error = MySQLClientError.invalidPacket("Received an invalid Result Set Header Packet")
-                    self = .done(result: error, capabilities: self.capabilities)
-                    return .error(error)
                 }
                 if !self.capabilities.metadataFlagAvailable || metadataFollows {
                     if columnCount == 0 {

--- a/Sources/MySQLNIO/Connection/MySQLChannelHandler+stateMachine.swift
+++ b/Sources/MySQLNIO/Connection/MySQLChannelHandler+stateMachine.swift
@@ -440,10 +440,10 @@ extension MySQLChannelHandler {
                 }
             case .query(var state):
                 switch state.stateMachine.receivedResponse(packet: &packet) {
-                case .metadataEnd, .metadataFollows:
+                case .doNothing:
                     self = .query(state)
                     return .doNothing
-                case .columnDefinition(_):
+                case .columnMetadata(_):
                     // TODO: handle column definitions
                     self = .query(state)
                     return .doNothing
@@ -850,9 +850,9 @@ extension MySQLChannelHandler.StateMachine {
             /// resultset has been signaled as incoming but not yet received.
             case awaitingResultsetStart
             /// Waiting for one or more column metadata packets
-            case awaitingColumnMetadata(columnsRemaining: UInt64)
+            case awaitingColumnMetadata(columnsRemaining: UInt64, columnMetadata: ColumnMetadata)
             /// Reading resultset rows
-            case readingRows
+            case readingRows(columnMetadata: ColumnMetadata)
             /// All result sets received, or error stopped the query.
             case done(result: (any Error)?)
         }
@@ -861,6 +861,17 @@ extension MySQLChannelHandler.StateMachine {
 
         @usableFromInline
         let capabilities: MySQLCapabilities
+
+        @usableFromInline
+        struct ColumnMetadata {
+            var columns: [ColumnDefinition]
+            var lookupTable: [String: Int]
+
+            init() {
+                self.columns = []
+                self.lookupTable = [:]
+            }
+        }
 
         init(capabilities: MySQLCapabilities) {
             self.state = .awaitingResultsetStart
@@ -874,10 +885,9 @@ extension MySQLChannelHandler.StateMachine {
 
         @usableFromInline
         enum ReceivedResponseAction {
-            case metadataFollows
-            case columnDefinition(ColumnDefinition)
-            case metadataEnd
-            case row(String)
+            case doNothing
+            case columnMetadata(ColumnMetadata)
+            case row(MySQLRow)
             case resultsetEnd
             case moreResultsExists
             case error(any Error)
@@ -913,29 +923,41 @@ extension MySQLChannelHandler.StateMachine {
                 }
                 if !self.capabilities.metadataFlagAvailable || metadataFollows {
                     if columnCount == 0 {
-                        self = .readingRows(capabilities: self.capabilities)
-                        return .metadataEnd
+                        self = .readingRows(columnMetadata: .init(), capabilities: self.capabilities)
+                        return .doNothing
                     } else {
-                        self = .awaitingColumnMetadata(columnsRemaining: columnCount, capabilities: self.capabilities)
-                        return .metadataFollows
+                        self = .awaitingColumnMetadata(
+                            columnsRemaining: columnCount,
+                            columnMetadata: .init(),
+                            capabilities: self.capabilities
+                        )
+                        return .doNothing
                     }
                 } else {
-                    self = .readingRows(capabilities: self.capabilities)
-                    return .metadataEnd
+                    self = .readingRows(columnMetadata: .init(), capabilities: self.capabilities)
+                    return .doNothing
                 }
-            case .awaitingColumnMetadata(let columnsRemaining):
-                if columnsRemaining == 1 {
-                    self = .readingRows(capabilities: self.capabilities)
-                } else {
-                    self = .awaitingColumnMetadata(columnsRemaining: columnsRemaining - 1, capabilities: self.capabilities)
-                }
-                guard let columnDefinition = ColumnDefinition(from: &packet, capabilities: self.capabilities) else {
+            case .awaitingColumnMetadata(let columnsRemaining, var columnMetadata):
+                guard let columnDefinition = ColumnDefinition(from: &packet, capabilities: self.capabilities, format: .text) else {
                     let error = MySQLClientError.invalidPacket("Received an invalid Column Definition Packet")
                     self = .done(result: error, capabilities: self.capabilities)
                     return .error(error)
                 }
-                return .columnDefinition(columnDefinition)
-            case .readingRows:
+                let nextColumnIndex = columnMetadata.columns.count
+                columnMetadata.columns.append(columnDefinition)
+                columnMetadata.lookupTable[columnDefinition.name] = nextColumnIndex
+                if columnsRemaining == 1 {
+                    self = .readingRows(columnMetadata: columnMetadata, capabilities: self.capabilities)
+                    return .columnMetadata(columnMetadata)
+                } else {
+                    self = .awaitingColumnMetadata(
+                        columnsRemaining: columnsRemaining - 1,
+                        columnMetadata: columnMetadata,
+                        capabilities: self.capabilities
+                    )
+                    return .doNothing
+                }
+            case .readingRows(let columnMetadata):
                 if packet.isEOFPacket {
                     guard let eofPacket = EOFPacket(from: &packet) else {
                         let error = MySQLClientError.invalidPacket("Received an invalid EOF Packet")
@@ -961,13 +983,14 @@ extension MySQLChannelHandler.StateMachine {
                     self = .done(result: nil, capabilities: self.capabilities)
                     return .resultsetEnd
                 } else {
-                    guard let row = packet.readLengthPrefixedString(strategy: .mySQL) else {
-                        let error = MySQLClientError.invalidPacket("Received an invalid Text Resultset Row packet")
-                        self = .done(result: error, capabilities: self.capabilities)
-                        return .error(error)
-                    }
-                    self = .readingRows(capabilities: self.capabilities)
-                    return .row(row)
+                    self = .readingRows(columnMetadata: columnMetadata, capabilities: self.capabilities)
+                    return .row(
+                        MySQLRow(
+                            data: .init(columnCount: UInt64(columnMetadata.columns.count), bytes: packet),
+                            lookupTable: columnMetadata.lookupTable,
+                            columns: columnMetadata.columns
+                        )
+                    )
                 }
             case .done:
                 preconditionFailure("Should not receive packets when query state machine is done")
@@ -978,12 +1001,16 @@ extension MySQLChannelHandler.StateMachine {
             Self(.awaitingResultsetStart, capabilities: capabilities)
         }
 
-        private static func awaitingColumnMetadata(columnsRemaining: UInt64, capabilities: MySQLCapabilities) -> Self {
-            Self(.awaitingColumnMetadata(columnsRemaining: columnsRemaining), capabilities: capabilities)
+        private static func awaitingColumnMetadata(
+            columnsRemaining: UInt64,
+            columnMetadata: ColumnMetadata,
+            capabilities: MySQLCapabilities
+        ) -> Self {
+            Self(.awaitingColumnMetadata(columnsRemaining: columnsRemaining, columnMetadata: columnMetadata), capabilities: capabilities)
         }
 
-        private static func readingRows(capabilities: MySQLCapabilities) -> Self {
-            Self(.readingRows, capabilities: capabilities)
+        private static func readingRows(columnMetadata: ColumnMetadata, capabilities: MySQLCapabilities) -> Self {
+            Self(.readingRows(columnMetadata: columnMetadata), capabilities: capabilities)
         }
 
         private static func done(result: (any Error)?, capabilities: MySQLCapabilities) -> Self {

--- a/Sources/MySQLNIO/Connection/MySQLChannelHandler+stateMachine.swift
+++ b/Sources/MySQLNIO/Connection/MySQLChannelHandler+stateMachine.swift
@@ -864,13 +864,8 @@ extension MySQLChannelHandler.StateMachine {
 
         @usableFromInline
         struct ColumnMetadata {
-            var columns: [ColumnDefinition]
-            var lookupTable: [String: Int]
-
-            init() {
-                self.columns = []
-                self.lookupTable = [:]
-            }
+            var columns: [ColumnDefinition] = []
+            var lookupTable: [String: Int] = [:]
         }
 
         init(capabilities: MySQLCapabilities) {

--- a/Sources/MySQLNIO/Connection/MySQLChannelHandler+stateMachine.swift
+++ b/Sources/MySQLNIO/Connection/MySQLChannelHandler+stateMachine.swift
@@ -875,7 +875,7 @@ extension MySQLChannelHandler.StateMachine {
         @usableFromInline
         enum ReceivedResponseAction {
             case metadataFollows
-            case columnDefinition(ColumnDefinitionPacket)
+            case columnDefinition(ColumnDefinition)
             case metadataEnd
             case row(String)
             case resultsetEnd
@@ -929,7 +929,7 @@ extension MySQLChannelHandler.StateMachine {
                 } else {
                     self = .awaitingColumnMetadata(columnsRemaining: columnsRemaining - 1, capabilities: self.capabilities)
                 }
-                guard let columnDefinition = ColumnDefinitionPacket(from: &packet, capabilities: self.capabilities) else {
+                guard let columnDefinition = ColumnDefinition(from: &packet, capabilities: self.capabilities) else {
                     let error = MySQLClientError.invalidPacket("Received an invalid Column Definition Packet")
                     self = .done(result: error, capabilities: self.capabilities)
                     return .error(error)

--- a/Sources/MySQLNIO/Connection/MySQLChannelHandler.swift
+++ b/Sources/MySQLNIO/Connection/MySQLChannelHandler.swift
@@ -10,7 +10,7 @@ final class MySQLChannelHandler: ChannelDuplexHandler {
         @usableFromInline
         enum CommandKind {
             case utility
-            case query(AsyncThrowingStream<String, any Error>.Continuation)
+            case query(MySQLRowSequence.Continuation)
         }
 
         @usableFromInline
@@ -362,7 +362,7 @@ final class MySQLChannelHandler: ChannelDuplexHandler {
         _ packet: ByteBuffer,
         promise: MySQLPromise<ByteBuffer>,
         requestID: Int,
-        continuation: AsyncThrowingStream<String, any Error>.Continuation
+        continuation: MySQLRowSequence.Continuation
     ) {
         self.eventLoop.assertInEventLoop()
         var command = PendingCommand(

--- a/Sources/MySQLNIO/Connection/MySQLConnection.swift
+++ b/Sources/MySQLNIO/Connection/MySQLConnection.swift
@@ -84,13 +84,13 @@ public final actor MySQLConnection: Sendable {
 
     public func query<Value>(
         _ query: String,
-        handler: (AsyncThrowingStream<String, any Error>) async throws -> Value
+        handler: (MySQLRowSequence) async throws -> Value
     ) async throws -> Value {
         var payload = self.channel.allocator.buffer(capacity: 4 + 1 + query.utf8.count)
         payload.writeBytes([0x00, 0x00, 0x00, 0x00])
         payload.writeInteger(UInt8(0x03))
         payload.writeString(query)
-        let (stream, continuation) = AsyncThrowingStream<String, any Error>.makeStream()
+        let (stream, continuation) = MySQLRowSequence.makeStream()
         try await self.sendQueryCommand(payload, streamContinuation: continuation)
         return try await handler(stream)
     }
@@ -326,7 +326,7 @@ extension MySQLConnection {
     }
 
     @usableFromInline
-    func sendQueryCommand(_ packet: ByteBuffer, streamContinuation: AsyncThrowingStream<String, any Error>.Continuation) async throws {
+    func sendQueryCommand(_ packet: ByteBuffer, streamContinuation: MySQLRowSequence.Continuation) async throws {
         let requestID = Self.requestIDGenerator.next()
         try await withTaskCancellationHandler {
             if Task.isCancelled {

--- a/Sources/MySQLNIO/Protocol/MySQLCollation.swift
+++ b/Sources/MySQLNIO/Protocol/MySQLCollation.swift
@@ -99,10 +99,14 @@ struct MySQLCollation: Hashable, Sendable {
     /// Apply the heuristic algorithm to determining the appropriate collation for a connection.
     static func bestCollation(forVersion version: String, capabilities: MySQLCapabilities) -> Self {
         if !capabilities.contains(.clientMySQL),  // MariaDB 10.10 or newer
-            version.starts(with: "10.10") || version.starts(with: "10.11") || version.starts(with: "11.") || version.starts(with: "12.")
+            // second character is not a dot, therefore there's more than one digit, i.e. > 9
+            version.dropFirst().first != "."
+                // 2+ digits not starting with 10. so >= 11, or is 10.10 or 10.11
+                // the trailing . on the check for 10 makes versions 100+ pass :D
+                && (!version.starts(with: "10.") || version.starts(with: "10.10") || version.starts(with: "10.11"))
         {
             .utf8Unicode14AICI
-        } else if capabilities.contains(.clientMySQL), version.starts(with: "8") || version.starts(with: "9") {
+        } else if capabilities.contains(.clientMySQL), Int(version.split(separator: ".").first ?? "") ?? 0 >= 8 {
             // non-MariaDB MySQL 8.0 or newer (or compatible)
             .utf8Unicode9AICI
         } else {  // anything else

--- a/Sources/MySQLNIO/Protocol/MySQLCollation.swift
+++ b/Sources/MySQLNIO/Protocol/MySQLCollation.swift
@@ -36,7 +36,7 @@
 ///
 ///    - Use `utf8mb4_unicode_520_ci`
 @usableFromInline
-struct MySQLCollation {
+struct MySQLCollation: Hashable, Sendable {
     /// The full name of the collation (e.g. `utf8mb4_0900_ai_ci`).
     let name: String
 

--- a/Sources/MySQLNIO/Protocol/MySQLCollation.swift
+++ b/Sources/MySQLNIO/Protocol/MySQLCollation.swift
@@ -35,6 +35,7 @@
 /// 3. In all other cases:
 ///
 ///    - Use `utf8mb4_unicode_520_ci`
+@usableFromInline
 struct MySQLCollation {
     /// The full name of the collation (e.g. `utf8mb4_0900_ai_ci`).
     let name: String

--- a/Sources/MySQLNIO/Protocol/MySQLDataType.swift
+++ b/Sources/MySQLNIO/Protocol/MySQLDataType.swift
@@ -8,15 +8,6 @@ public enum MySQLFormat: Sendable {
     case text
 }
 
-extension MySQLFormat: CustomStringConvertible {
-    public var description: String {
-        switch self {
-        case .binary: "binary"
-        case .text: "text"
-        }
-    }
-}
-
 /// The raw wire-level type of a MySQL value.
 ///
 /// These are all of the possible types a given value might have, from MySQL's perspective.

--- a/Sources/MySQLNIO/Protocol/MySQLDataType.swift
+++ b/Sources/MySQLNIO/Protocol/MySQLDataType.swift
@@ -1,0 +1,195 @@
+/// The format the MySQL types are encoded in on the wire.
+///
+/// Currently there are two wire formats supported:
+///  - binary
+///  - text
+public enum MySQLFormat: Sendable {
+    case binary
+    case text
+}
+
+extension MySQLFormat: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .binary: "binary"
+        case .text: "text"
+        }
+    }
+}
+
+/// The raw wire-level type of a MySQL value.
+///
+/// These are all of the possible types a given value might have, from MySQL's perspective.
+/// When the binary protocol encoding is used, they also describe a value's wire format;
+/// for the text protocol encoding, they act as type affinities describing how best to interpret a given value.
+///
+/// > Note: Several of the type codes listed here are considered internal to MySQL.
+/// > These types are implementation details of the server's internal storage formats;
+/// > most of them are either "new" versions of old types or vice versa.
+/// > In both cases, the server is expected to translate between the "internal" versions and the "normal" ones transparently in both directions;
+/// > we include limited handling of the internal ones here in order to be resilient against badly behaved servers.
+/// >
+/// > There are a few "internal" types which are _not_ alternate versions of other types;
+/// > these are commented out here, as they can not be sensibly handled and should never be used.
+public struct MySQLDataType: RawRepresentable, Sendable, Hashable, CustomStringConvertible {
+    // MARK: - Integers
+
+    /// - term **MySQL name**: `MYSQL_TYPE_TINY`
+    public static var tinyint: Self { .init(rawValue: 1) }
+    /// - term **MySQL name**: `MYSQL_TYPE_SHORT`
+    public static var smallint: Self { .init(rawValue: 2) }
+    /// - term **MySQL name**: `MYSQL_TYPE_INT24`
+    public static var mediumint: Self { .init(rawValue: 9) }
+    /// - term **MySQL name**: `MYSQL_TYPE_LONG`
+    public static var integer: Self { .init(rawValue: 3) }
+    /// - term **MySQL name**: `MYSQL_TYPE_LONGLONG`
+    public static var bigint: Self { .init(rawValue: 8) }
+
+    // MARK: Decimals
+
+    /// - term **MySQL name**: `MYSQL_TYPE_FLOAT`
+    public static var float: Self { .init(rawValue: 4) }
+    /// - term **MySQL name**: `MYSQL_TYPE_DOUBLE`
+    public static var double: Self { .init(rawValue: 5) }
+    /// Used for both `DECIMAL` and `NUMERIC`.
+    /// - term **MySQL name**: `MYSQL_TYPE_DECIMAL`
+    public static var decimal: Self { .init(rawValue: 0) }
+
+    // MARK: Temporal
+
+    /// - term **MySQL name**: `MYSQL_TYPE_TIMESTAMP`
+    public static var timestamp: Self { .init(rawValue: 7) }
+    /// - term **MySQL name**: `MYSQL_TYPE_DATE`
+    public static var date: Self { .init(rawValue: 10) }
+    /// - term **MySQL name**: `MYSQL_TYPE_TIME`
+    public static var time: Self { .init(rawValue: 11) }
+    /// - term **MySQL name**: `MYSQL_TYPE_DATETIME`
+    public static var datetime: Self { .init(rawValue: 12) }
+    /// - term **MySQL name**: `MYSQL_TYPE_YEAR`
+    public static var year: Self { .init(rawValue: 13) }
+
+    // MARK: Unstructured
+
+    /// - term **MySQL name**: `MYSQL_TYPE_BIT`
+    public static var bit: Self { .init(rawValue: 16) }
+    /// Used for both `CHAR` and `BINARY`.
+    /// - term **MySQL name**: `MYSQL_TYPE_STRING`
+    public static var char: Self { .init(rawValue: 254) }
+    /// Used for both `VARCHAR` and `VARBINARY`.
+    /// - term **MySQL name**: `MYSQL_TYPE_VARCHAR`
+    public static var varchar: Self { .init(rawValue: 15) }
+    /// Used for both `TINYBLOB` and `TINYTEXT`.
+    /// - term **MySQL name**: `MYSQL_TYPE_TINY_BLOB`
+    public static var tinyblob: Self { .init(rawValue: 249) }
+    /// Used for both `BLOB` and `TEXT`.
+    /// - term **MySQL name**: `MYSQL_TYPE_BLOB`
+    public static var blob: Self { .init(rawValue: 250) }
+    /// Used for both `MEDIUMBLOB` and `MEDIUMTEXT`.
+    /// - term **MySQL name**: `MYSQL_TYPE_MEDIUM_BLOB`
+    public static var mediumblob: Self { .init(rawValue: 251) }
+    /// Used for both `LONGBLOB` and `LONGTEXT`.
+    /// - term **MySQL name**: `MYSQL_TYPE_LONG_BLOB`
+    public static var longblob: Self { .init(rawValue: 252) }
+
+    // MARK: Complex
+
+    /// - term **MySQL name**: `MYSQL_TYPE_JSON`
+    public static var json: Self { .init(rawValue: 245) }
+    /// - term **MySQL name**: `MYSQL_TYPE_ENUM`
+    public static var `enum`: Self { .init(rawValue: 247) }
+    /// - term **MySQL name**: `MYSQL_TYPE_SET`
+    public static var set: Self { .init(rawValue: 248) }
+    /// - term **MySQL name**: `MYSQL_TYPE_GEOMETRY`
+    public static var geometry: Self { .init(rawValue: 255) }
+
+    // MARK: Meta
+
+    /// An otherwise untyped `NULL` value.
+    ///
+    /// Used when convenient as an alternative to ``unknown`` for known-`NULL`s.
+    ///
+    /// - term **MySQL name**: `MYSQL_TYPE_NULL`
+    public static var null: Self { .init(rawValue: 6) }
+
+    /// A value with unknown or otherwise indeterminate type.
+    ///
+    /// Used internally by MySQL, and also internally by this package, to represent a
+    /// parameter value having no explicit type. Using it in the wire protocol is a
+    /// protocol violation.
+    ///
+    /// - term **MySQL name**: `MYSQL_TYPE_INVALID`
+    public static var unknown: Self { .init(rawValue: 243) }
+
+    // MARK: Internal
+
+    /// - term **MySQL name**: `MYSQL_TYPE_NEWDATE`    (replaces `MYSQL_TYPE_DATE` internally to MySQL)
+    static var _newdate: Self { .init(rawValue: 14) }
+    /// - term **MySQL name**: `MYSQL_TYPE_TIMESTAMP2` (replaces `MYSQL_TYPE_TIMESTAMP` internally to MySQL)
+    static var _timestamp2: Self { .init(rawValue: 17) }
+    /// - term **MySQL name**: `MYSQL_TYPE_DATETIME2`  (replaces `MYSQL_TYPE_DATETIME` internally to MySQL)
+    static var _datetime2: Self { .init(rawValue: 18) }
+    /// - term **MySQL name**: `MYSQL_TYPE_TIME2`      (replaces `MYSQL_TYPE_TIME` internally to MySQL)
+    static var _time2: Self { .init(rawValue: 19) }
+    /// - term **MySQL name**: `MYSQL_TYPE_NEWDECIMAL` (replaces `MYSQL_TYPE_DECIMAL` internally to MySQL)
+    static var _newdecimal: Self { .init(rawValue: 246) }
+    /// - term **MySQL name**: `MYSQL_TYPE_VAR_STRING` (replaced by `MYSQL_TYPE_VARCHAR` internally to MySQL)
+    static var _varstring: Self { .init(rawValue: 253) }
+
+    //static var _typedArray:     Self { .init(rawValue:  20) } // `MYSQL_TYPE_TYPED_ARRAY` - internal implementation detail of replication
+    //static var _bool:           Self { .init(rawValue: 244) } // `MYSQL_TYPE_BOOL`        - defined but unimplemented, treated like MYSQL_TYPE_INVALID
+
+    /// The raw data type code recognized by MySQL.
+    public let rawValue: UInt8
+
+    public init(rawValue: UInt8) { self.rawValue = rawValue }
+
+    /// Returns the known SQL name, if one exists.
+    ///
+    /// > Note: This only supports a limited subset of all MySQL types and is meant for convenience only.
+    ///
+    /// This list was manually generated.
+    public var knownSQLName: String? {
+        switch self {
+        case .tinyint: "TINYINT"
+        case .smallint: "SMALLINT"
+        case .mediumint: "MEDIUMINT"
+        case .integer: "INT"
+        case .bigint: "BIGINT"
+        case .float: "FLOAT"
+        case .double: "DOUBLE"
+        case .decimal: "DECIMAL"
+        case .timestamp: "TIMESTAMP"
+        case .date: "DATE"
+        case .time: "TIME"
+        case .datetime: "DATETIME"
+        case .year: "YEAR"
+        case .bit: "BIT"
+        case .char: "CHAR"
+        case .varchar: "VARCHAR"
+        case .tinyblob: "TINYBLOB"
+        case .blob: "BLOB"
+        case .mediumblob: "MEDIUMBLOB"
+        case .longblob: "LONGBLOB"
+        case .json: "JSON"
+        case .enum: "ENUM"
+        case .set: "SET"
+        case .geometry: "GEOMETRY"
+        case .null: "<NULL>"
+        case .unknown: "?INVALID?"
+        case ._newdate: "_NEWDATE"
+        case ._timestamp2: "_TIMESTAMP2"
+        case ._datetime2: "_DATETIME2"
+        case ._time2: "_TIME2"
+        case ._newdecimal: "_NEWDECIMAL"
+        case ._varstring: "_VARSTRING"
+        case .init(rawValue: 20): "_typedarray"
+        case .init(rawValue: 244): "_bool"
+        default: nil
+        }
+    }
+
+    // See `CustomStringConvertible.description`.
+    public var description: String {
+        self.knownSQLName ?? "<unknown(\(self.rawValue))>"
+    }
+}

--- a/Sources/MySQLNIO/Protocol/Packets/Generic Response Packets/Result Set Packets/ColumnDefinition.swift
+++ b/Sources/MySQLNIO/Protocol/Packets/Generic Response Packets/Result Set Packets/ColumnDefinition.swift
@@ -1,27 +1,61 @@
 import NIOCore
 
 @usableFromInline
-struct ColumnDefinitionPacket {
+struct ColumnDefinition {
+    /// Schema name
+    @usableFromInline
     let schema: String
-    let tableAlias: String
-    let tableName: String
-    let columnAlias: String
-    let columnName: String
+
+    /// Virtual table name
+    @usableFromInline
+    let table: String
+
+    /// Physical table name
+    @usableFromInline
+    let orgTable: String
+
+    /// Virtual column name
+    @usableFromInline
+    let name: String
+
+    /// Physical column name
+    @usableFromInline
+    let orgName: String
+
+    /// See `MARIADB_CLIENT_EXTENDED_METADATA`
+    @usableFromInline
     let extendedMetadata: String?
+
+    /// The column character set
+    @usableFromInline
     let characterSet: MySQLCollation
-    let maxColumnSize: UInt32
+
+    /// Maximum length of the field
+    @usableFromInline
+    let columnLength: UInt32
+
+    /// Type of the column
+    @usableFromInline
     let type: MySQLDataType
+
+    @usableFromInline
     let flags: UInt16
+
+    /// Max shown decimal digits:
+    /// - `0x00` for integers and static strings
+    /// - `0x1f` for dynamic strings, double, float
+    /// - `0x00` to `0x51` for decimals
+    @usableFromInline
     let decimals: UInt8
 
     init?(from packet: inout ByteBuffer, capabilities: MySQLCapabilities) {
         guard
             let catalog = packet.readLengthPrefixedString(strategy: .mySQL), catalog == "def",
             let schema = packet.readLengthPrefixedString(strategy: .mySQL),
-            let tableAlias = packet.readLengthPrefixedString(strategy: .mySQL),
-            let tableName = packet.readLengthPrefixedString(strategy: .mySQL),
-            let columnAlias = packet.readLengthPrefixedString(strategy: .mySQL),
-            let columnName = packet.readLengthPrefixedString(strategy: .mySQL)
+            let table = packet.readLengthPrefixedString(strategy: .mySQL),
+            let orgTable = packet.readLengthPrefixedString(strategy: .mySQL),
+            let name = packet.readLengthPrefixedString(strategy: .mySQL),
+            let orgName = packet.readLengthPrefixedString(strategy: .mySQL)
         else {
             return nil
         }
@@ -34,7 +68,7 @@ struct ColumnDefinitionPacket {
         guard
             let fixedFieldsLength = packet.readEncodedInteger(as: UInt8.self, strategy: .mySQL), fixedFieldsLength == 0x0C,
             let characterSetRaw = packet.readInteger(endianness: .little, as: UInt16.self),
-            let maxColumnSize = packet.readInteger(endianness: .little, as: UInt32.self),
+            let columnLength = packet.readInteger(endianness: .little, as: UInt32.self),
             let type = packet.readInteger(as: UInt8.self),
             let flags = packet.readInteger(endianness: .little, as: UInt16.self),
             let decimals = packet.readInteger(as: UInt8.self)
@@ -43,12 +77,12 @@ struct ColumnDefinitionPacket {
         }
         packet.moveReaderIndex(forwardBy: 2)  // - unused -
         self.schema = schema
-        self.tableAlias = tableAlias
-        self.tableName = tableName
-        self.columnAlias = columnAlias
-        self.columnName = columnName
+        self.table = table
+        self.orgTable = orgTable
+        self.name = name
+        self.orgName = orgName
         self.characterSet = .lookup(byId: characterSetRaw)
-        self.maxColumnSize = maxColumnSize
+        self.columnLength = columnLength
         self.type = MySQLDataType(rawValue: type)
         self.flags = flags
         self.decimals = decimals

--- a/Sources/MySQLNIO/Protocol/Packets/Generic Response Packets/Result Set Packets/ColumnDefinition.swift
+++ b/Sources/MySQLNIO/Protocol/Packets/Generic Response Packets/Result Set Packets/ColumnDefinition.swift
@@ -36,7 +36,7 @@ struct ColumnDefinition: Hashable, Sendable {
 
     /// Type of the column
     @usableFromInline
-    let type: MySQLDataType
+    let dataType: MySQLDataType
 
     @usableFromInline
     let flags: UInt16
@@ -48,7 +48,14 @@ struct ColumnDefinition: Hashable, Sendable {
     @usableFromInline
     let decimals: UInt8
 
-    init?(from packet: inout ByteBuffer, capabilities: MySQLCapabilities) {
+    /// The format in which the column values are encoded (either text or binary).
+    ///
+    /// > Note: This is not part of the packet in the MySQL protocol,
+    /// > we set it when we parse the packet to then know how to decode the column values.
+    @usableFromInline
+    let format: MySQLFormat
+
+    init?(from packet: inout ByteBuffer, capabilities: MySQLCapabilities, format: MySQLFormat) {
         guard
             let catalog = packet.readLengthPrefixedString(strategy: .mySQL), catalog == "def",
             let schema = packet.readLengthPrefixedString(strategy: .mySQL),
@@ -83,8 +90,57 @@ struct ColumnDefinition: Hashable, Sendable {
         self.orgName = orgName
         self.characterSet = .lookup(byId: characterSetRaw)
         self.columnLength = columnLength
-        self.type = MySQLDataType(rawValue: type)
+        self.dataType = MySQLDataType(rawValue: type)
         self.flags = flags
         self.decimals = decimals
+
+        self.format = format
+    }
+
+    package init(
+        schema: String,
+        table: String,
+        orgTable: String,
+        name: String,
+        orgName: String,
+        extendedMetadata: String?,
+        characterSet: MySQLCollation,
+        columnLength: UInt32,
+        dataType: MySQLDataType,
+        flags: UInt16,
+        decimals: UInt8,
+        format: MySQLFormat
+    ) {
+        self.schema = schema
+        self.table = table
+        self.orgTable = orgTable
+        self.name = name
+        self.orgName = orgName
+        self.extendedMetadata = extendedMetadata
+        self.characterSet = characterSet
+        self.columnLength = columnLength
+        self.dataType = dataType
+        self.flags = flags
+        self.decimals = decimals
+        self.format = format
+    }
+
+    package func write(to packet: inout ByteBuffer, capabilities: MySQLCapabilities) {
+        packet.writeLengthPrefixedString("def", strategy: .mySQL)
+        packet.writeLengthPrefixedString(self.schema, strategy: .mySQL)
+        packet.writeLengthPrefixedString(self.table, strategy: .mySQL)
+        packet.writeLengthPrefixedString(self.orgTable, strategy: .mySQL)
+        packet.writeLengthPrefixedString(self.name, strategy: .mySQL)
+        packet.writeLengthPrefixedString(self.orgName, strategy: .mySQL)
+        if capabilities.contains(.mariaDBClientExtendedMetadata), let extendedMetadata = self.extendedMetadata {
+            packet.writeLengthPrefixedString(extendedMetadata, strategy: .mySQL)
+        }
+        packet.writeEncodedInteger(0x0C, strategy: .mySQL)  // length of the following fixed-length fields
+        packet.writeInteger(self.characterSet.id, endianness: .little, as: UInt16.self)
+        packet.writeInteger(self.columnLength, endianness: .little, as: UInt32.self)
+        packet.writeInteger(self.dataType.rawValue, as: UInt8.self)
+        packet.writeInteger(self.flags, endianness: .little, as: UInt16.self)
+        packet.writeInteger(self.decimals, as: UInt8.self)
+        packet.writeInteger(0x00, as: UInt16.self)  // filler
     }
 }

--- a/Sources/MySQLNIO/Protocol/Packets/Generic Response Packets/Result Set Packets/ColumnDefinition.swift
+++ b/Sources/MySQLNIO/Protocol/Packets/Generic Response Packets/Result Set Packets/ColumnDefinition.swift
@@ -1,7 +1,7 @@
 import NIOCore
 
 @usableFromInline
-struct ColumnDefinition {
+struct ColumnDefinition: Hashable, Sendable {
     /// Schema name
     @usableFromInline
     let schema: String

--- a/Sources/MySQLNIO/Protocol/Packets/Generic Response Packets/Result Set Packets/ColumnDefinitionPacket.swift
+++ b/Sources/MySQLNIO/Protocol/Packets/Generic Response Packets/Result Set Packets/ColumnDefinitionPacket.swift
@@ -10,7 +10,7 @@ struct ColumnDefinitionPacket {
     let extendedMetadata: String?
     let characterSet: MySQLCollation
     let maxColumnSize: UInt32
-    let type: UInt8
+    let type: MySQLDataType
     let flags: UInt16
     let decimals: UInt8
 
@@ -49,7 +49,7 @@ struct ColumnDefinitionPacket {
         self.columnName = columnName
         self.characterSet = .lookup(byId: characterSetRaw)
         self.maxColumnSize = maxColumnSize
-        self.type = type
+        self.type = MySQLDataType(rawValue: type)
         self.flags = flags
         self.decimals = decimals
     }

--- a/Sources/MySQLNIO/Query/DataRow.swift
+++ b/Sources/MySQLNIO/Query/DataRow.swift
@@ -36,12 +36,12 @@ extension DataRow: Collection {
     typealias Index = DataRow.ColumnIndex
 
     @inlinable
-    var startIndex: Self {
+    var startIndex: Index {
         .init(self.bytes.readerIndex)
     }
 
     @inlinable
-    var endIndex: Self {
+    var endIndex: Index {
         .init(self.bytes.readerIndex + self.bytes.readableBytes)
     }
 

--- a/Sources/MySQLNIO/Query/DataRow.swift
+++ b/Sources/MySQLNIO/Query/DataRow.swift
@@ -41,8 +41,8 @@ extension DataRow: Collection {
     }
 
     @inlinable
-    var endIndex: ColumnIndex {
-        ColumnIndex(self.bytes.readerIndex + self.bytes.readableBytes)
+    var endIndex: Self {
+        .init(self.bytes.readerIndex + self.bytes.readableBytes)
     }
 
     @inlinable

--- a/Sources/MySQLNIO/Query/DataRow.swift
+++ b/Sources/MySQLNIO/Query/DataRow.swift
@@ -1,0 +1,109 @@
+public import NIOCore
+
+/// A backend data row message.
+@usableFromInline
+struct DataRow: Sendable, Hashable {
+    @usableFromInline
+    var columnCount: UInt64
+    @usableFromInline
+    var bytes: ByteBuffer
+}
+
+extension DataRow: Sequence {
+    @usableFromInline
+    typealias Element = ByteBuffer?
+}
+
+extension DataRow: Collection {
+    @usableFromInline
+    struct ColumnIndex: Comparable {
+        @usableFromInline
+        var offset: Int
+
+        @inlinable
+        init(_ index: Int) {
+            self.offset = index
+        }
+
+        // Only needed implementation for `Comparable`. The compiler synthesizes the rest from this.
+        @inlinable
+        static func < (lhs: Self, rhs: Self) -> Bool {
+            lhs.offset < rhs.offset
+        }
+    }
+
+    @usableFromInline
+    typealias Index = DataRow.ColumnIndex
+
+    @inlinable
+    var startIndex: ColumnIndex {
+        ColumnIndex(self.bytes.readerIndex)
+    }
+
+    @inlinable
+    var endIndex: ColumnIndex {
+        ColumnIndex(self.bytes.readerIndex + self.bytes.readableBytes)
+    }
+
+    @inlinable
+    var count: Int {
+        Int(self.columnCount)
+    }
+
+    @inlinable
+    func index(after index: ColumnIndex) -> ColumnIndex {
+        guard index < self.endIndex else {
+            preconditionFailure("index out of bounds")
+        }
+
+        guard let header = self.bytes.getInteger(at: index.offset, as: UInt8.self) else {
+            preconditionFailure("invalid row data")
+        }
+        if header == 0xFB {
+            return ColumnIndex(index.offset + 1)
+        }
+
+        var copy = self.bytes
+        copy.moveReaderIndex(to: index.offset)
+        guard copy.readLengthPrefixedSlice(strategy: .mySQL) != nil else {
+            preconditionFailure("invalid row data")
+        }
+        return ColumnIndex(copy.readerIndex)
+    }
+
+    @inlinable
+    subscript(index: ColumnIndex) -> Element {
+        guard index < self.endIndex else {
+            preconditionFailure("index out of bounds")
+        }
+
+        guard let header = self.bytes.getInteger(at: index.offset, as: UInt8.self) else {
+            preconditionFailure("invalid row data")
+        }
+        if header == 0xFB {
+            return nil
+        }
+
+        var copy = self.bytes
+        copy.moveReaderIndex(to: index.offset)
+        guard let value = copy.readLengthPrefixedSlice(strategy: .mySQL) else {
+            preconditionFailure("invalid row data")
+        }
+        return value
+    }
+}
+
+extension DataRow {
+    subscript(column index: Int) -> Element {
+        guard index < self.columnCount else {
+            preconditionFailure("index out of bounds")
+        }
+
+        var byteIndex = self.startIndex
+        for _ in 0..<index {
+            byteIndex = self.index(after: byteIndex)
+        }
+
+        return self[byteIndex]
+    }
+}

--- a/Sources/MySQLNIO/Query/DataRow.swift
+++ b/Sources/MySQLNIO/Query/DataRow.swift
@@ -99,11 +99,6 @@ extension DataRow {
             preconditionFailure("index out of bounds")
         }
 
-        var byteIndex = self.startIndex
-        for _ in 0..<index {
-            byteIndex = self.index(after: byteIndex)
-        }
-
-        return self[byteIndex]
+        return self[self.index(self.startIndex, offsetBy: index)]
     }
 }

--- a/Sources/MySQLNIO/Query/DataRow.swift
+++ b/Sources/MySQLNIO/Query/DataRow.swift
@@ -16,7 +16,7 @@ extension DataRow: Sequence {
 
 extension DataRow: Collection {
     @usableFromInline
-    struct ColumnIndex: Comparable {
+    struct ColumnIndex: Comparable, Hashable {
         @usableFromInline
         var offset: Int
 

--- a/Sources/MySQLNIO/Query/DataRow.swift
+++ b/Sources/MySQLNIO/Query/DataRow.swift
@@ -36,8 +36,8 @@ extension DataRow: Collection {
     typealias Index = DataRow.ColumnIndex
 
     @inlinable
-    var startIndex: ColumnIndex {
-        ColumnIndex(self.bytes.readerIndex)
+    var startIndex: Self {
+        .init(self.bytes.readerIndex)
     }
 
     @inlinable

--- a/Sources/MySQLNIO/Query/MySQLCell.swift
+++ b/Sources/MySQLNIO/Query/MySQLCell.swift
@@ -1,0 +1,31 @@
+public import NIOCore
+
+/// A representation of a cell value within a ``MySQLRow`` and ``MySQLRandomAccessRow``.
+public struct MySQLCell: Sendable, Equatable {
+    /// The cell's value as raw bytes.
+    public var bytes: ByteBuffer?
+    /// The cell's data type. This is important metadata when decoding the cell.
+    public var dataType: MySQLDataType
+    /// The format in which the cell's bytes are encoded.
+    public var format: MySQLFormat
+
+    /// The cell's column name within the row.
+    public var columnName: String
+    /// The cell's column index within the row.
+    public var columnIndex: Int
+
+    public init(
+        bytes: ByteBuffer?,
+        dataType: MySQLDataType,
+        format: MySQLFormat,
+        columnName: String,
+        columnIndex: Int
+    ) {
+        self.bytes = bytes
+        self.dataType = dataType
+        self.format = format
+
+        self.columnName = columnName
+        self.columnIndex = columnIndex
+    }
+}

--- a/Sources/MySQLNIO/Query/MySQLRow.swift
+++ b/Sources/MySQLNIO/Query/MySQLRow.swift
@@ -1,0 +1,183 @@
+import NIOCore
+
+/// `MySQLRow` represents a single table row that is received from the server for a query or a prepared statement.
+/// Its element type is ``MySQLCell``.
+///
+/// > Warning: Please note that random access to cells in a ``MySQLRow`` has O(n) time complexity.
+/// > If you require random access to cells in O(1),
+/// > create a new ``MySQLRandomAccessRow`` with the given row and access it instead.
+public struct MySQLRow: Sendable {
+    @usableFromInline
+    let lookupTable: [String: Int]
+    @usableFromInline
+    let data: DataRow
+    @usableFromInline
+    let columns: [ColumnDefinition]
+
+    init(data: DataRow, lookupTable: [String: Int], columns: [ColumnDefinition]) {
+        self.data = data
+        self.lookupTable = lookupTable
+        self.columns = columns
+    }
+}
+
+extension MySQLRow: Equatable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        // We don't need to compare the lookup table here,
+        // as the lookup table is only derived from the column definitions.
+        lhs.data == rhs.data && lhs.columns == rhs.columns
+    }
+}
+
+extension MySQLRow: Sequence {
+    public typealias Element = MySQLCell
+
+    public struct Iterator: IteratorProtocol {
+        public typealias Element = MySQLCell
+
+        private(set) var columnIndex: Array<ColumnDefinition>.Index
+        private(set) var columnIterator: Array<ColumnDefinition>.Iterator
+        private(set) var dataIterator: DataRow.Iterator
+
+        init(_ row: MySQLRow) {
+            self.columnIndex = 0
+            self.columnIterator = row.columns.makeIterator()
+            self.dataIterator = row.data.makeIterator()
+        }
+
+        public mutating func next() -> MySQLCell? {
+            guard let bytes = self.dataIterator.next() else {
+                return nil
+            }
+
+            let column = self.columnIterator.next()!
+
+            defer { self.columnIndex += 1 }
+
+            return MySQLCell(
+                bytes: bytes,
+                dataType: column.dataType,
+                format: column.format,
+                columnName: column.name,
+                columnIndex: columnIndex
+            )
+        }
+    }
+
+    public func makeIterator() -> Iterator {
+        Iterator(self)
+    }
+}
+
+extension MySQLRow: Collection {
+    public struct Index: Comparable {
+        var cellIndex: DataRow.Index
+        var columnIndex: Array<ColumnDefinition>.Index
+
+        // Only needed implementation for `Comparable`. The compiler synthesizes the rest from this.
+        public static func < (lhs: Self, rhs: Self) -> Bool {
+            lhs.columnIndex < rhs.columnIndex
+        }
+    }
+
+    public subscript(position: Index) -> MySQLCell {
+        // TODO: Fix crash when there is no column definitions (i.e. when `metadata_follows = 0`)
+        let column = self.columns[position.columnIndex]
+        return MySQLCell(
+            bytes: self.data[position.cellIndex],
+            dataType: column.dataType,
+            format: column.format,
+            columnName: column.name,
+            columnIndex: position.columnIndex
+        )
+    }
+
+    public var startIndex: Index {
+        Index(
+            cellIndex: self.data.startIndex,
+            columnIndex: 0
+        )
+    }
+
+    public var endIndex: Index {
+        Index(
+            cellIndex: self.data.endIndex,
+            columnIndex: self.columns.count
+        )
+    }
+
+    public func index(after i: Index) -> Index {
+        Index(
+            cellIndex: self.data.index(after: i.cellIndex),
+            columnIndex: self.columns.index(after: i.columnIndex)
+        )
+    }
+
+    public var count: Int {
+        self.data.count
+    }
+}
+
+extension MySQLRow {
+    public func makeRandomAccess() -> MySQLRandomAccessRow {
+        MySQLRandomAccessRow(self)
+    }
+}
+
+/// A random access row of ``MySQLCell``s.
+///
+/// Its initialization is O(n), where n is the number of columns in the row. All subsequent cell accesses are O(1).
+public struct MySQLRandomAccessRow {
+    let columns: [ColumnDefinition]
+    let cells: [ByteBuffer?]
+    let lookupTable: [String: Int]
+
+    public init(_ row: MySQLRow) {
+        self.cells = [ByteBuffer?](row.data)
+        self.columns = row.columns
+        self.lookupTable = row.lookupTable
+    }
+}
+
+extension MySQLRandomAccessRow: Sendable, RandomAccessCollection {
+    public typealias Element = MySQLCell
+    public typealias Index = Int
+
+    public var startIndex: Int { 0 }
+
+    public var endIndex: Int {
+        self.columns.count
+    }
+
+    public var count: Int {
+        self.columns.count
+    }
+
+    public subscript(index: Int) -> MySQLCell {
+        guard index < self.endIndex else {
+            preconditionFailure("index out of bounds")
+        }
+        let column = self.columns[index]
+        return MySQLCell(
+            bytes: self.cells[index],
+            dataType: column.dataType,
+            format: column.format,
+            columnName: column.name,
+            columnIndex: index
+        )
+    }
+
+    public subscript(name: String) -> MySQLCell {
+        guard let index = self.lookupTable[name] else {
+            fatalError(#"A column "\#(name)" does not exist."#)
+        }
+        return self[index]
+    }
+
+    /// Checks if the row contains a cell for the given column name.
+    /// - Parameter column: The column name to check against.
+    /// - Returns: `true` if the row contains this column, `false` if it does not.
+    public func contains(_ column: String) -> Bool {
+        self.lookupTable[column] != nil
+    }
+}

--- a/Sources/MySQLNIO/Query/MySQLRow.swift
+++ b/Sources/MySQLNIO/Query/MySQLRow.swift
@@ -167,9 +167,9 @@ extension MySQLRandomAccessRow: Sendable, RandomAccessCollection {
         )
     }
 
-    public subscript(name: String) -> MySQLCell {
+    public subscript(name: String) -> MySQLCell? {
         guard let index = self.lookupTable[name] else {
-            fatalError(#"A column "\#(name)" does not exist."#)
+            return nil
         }
         return self[index]
     }

--- a/Sources/MySQLNIO/Query/MySQLRowSequence.swift
+++ b/Sources/MySQLNIO/Query/MySQLRowSequence.swift
@@ -1,0 +1,51 @@
+/// An async sequence of ``MySQLRow``s.
+///
+/// - Note: This is a struct to allow us to move to a move-only type easily once they become available.
+public struct MySQLRowSequence: AsyncSequence, Sendable {
+    public typealias Element = MySQLRow
+
+    @usableFromInline
+    typealias BackingSequence = AsyncThrowingStream<Element, any Error>
+    @usableFromInline
+    typealias Continuation = BackingSequence.Continuation
+
+    let backing: BackingSequence
+    // TODO: public let columns: [ColumnDefinition]
+
+    static func makeStream() -> (Self, Self.Continuation) {
+        let (stream, continuation) = BackingSequence.makeStream()
+        return (.init(backing: stream), continuation)
+    }
+
+    public func makeAsyncIterator() -> AsyncIterator {
+        AsyncIterator(base: self.backing.makeAsyncIterator())
+    }
+}
+
+extension MySQLRowSequence {
+    public struct AsyncIterator: AsyncIteratorProtocol {
+        var base: BackingSequence.AsyncIterator
+
+        @concurrent
+        public mutating func next() async throws -> Element? {
+            try await self.base.next()
+        }
+
+        public mutating func next(isolation actor: isolated (any Actor)?) async throws(any Error) -> Element? {
+            try await self.base.next(isolation: actor)
+        }
+    }
+}
+
+@available(*, unavailable)
+extension MySQLRowSequence.AsyncIterator: Sendable {}
+
+extension MySQLRowSequence {
+    public func collect() async throws -> [Element] {
+        var result = [Element]()
+        for try await row in self {
+            result.append(row)
+        }
+        return result
+    }
+}

--- a/Tests/IntegrationTests/MySQLConnectionTests.swift
+++ b/Tests/IntegrationTests/MySQLConnectionTests.swift
@@ -1,5 +1,6 @@
 import Logging
 import MySQLNIO
+import NIOCore
 import NIOSSL
 import Testing
 
@@ -13,8 +14,8 @@ import Foundation
 struct MySQLConnectionTests {
     let mySQLHostname = ProcessInfo.processInfo.environment["MYSQL_HOSTNAME"] ?? "localhost"
 
-    @Test("Query")
-    func query() async throws {
+    @Test("Select Version")
+    func selectVersion() async throws {
         try await MySQLConnection.withConnection(
             address: .hostname(mySQLHostname),
             configuration: .init(username: "test_username", password: "test_password"),
@@ -22,8 +23,67 @@ struct MySQLConnectionTests {
         ) { connection in
             try await connection.query("SELECT @@version") { rows in
                 for try await row in rows {
-                    #expect(row.contains("."))
+                    for cell in row {
+                        let version = String(buffer: try #require(cell.bytes))
+                        #expect(version.contains("."))
+                    }
                 }
+            }
+        }
+    }
+
+    @Test("Select String")
+    func selectString() async throws {
+        try await MySQLConnection.withConnection(
+            address: .hostname(mySQLHostname),
+            configuration: .init(username: "test_username", password: "test_password"),
+            logger: logger
+        ) { connection in
+            try await connection.query("SELECT 'foo' as bar") { rows in
+                for try await row in rows {
+                    for cell in row {
+                        #expect(cell.columnName == "bar")
+                        let value = String(buffer: try #require(cell.bytes))
+                        #expect(value == "foo")
+                    }
+                }
+            }
+        }
+    }
+
+    @Test("Select Integers")
+    func selectIntegers() async throws {
+        try await MySQLConnection.withConnection(
+            address: .hostname(mySQLHostname),
+            configuration: .init(username: "test_username", password: "test_password"),
+            logger: logger
+        ) { connection in
+            try await connection.query("SELECT '1' as one, 2 as two") { rows in
+                for try await row in rows {
+                    for cell in row {
+                        let value = String(buffer: try #require(cell.bytes))
+                        switch cell.columnName {
+                        case "one": #expect(value == "1")
+                        case "two": #expect(value == "2")
+                        default: Issue.record()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test("No Response")
+    func noResponse() async throws {
+        try await MySQLConnection.withConnection(
+            address: .hostname(mySQLHostname),
+            configuration: .init(username: "test_username", password: "test_password"),
+            logger: logger
+        ) { connection in
+            try await connection.query("SET @foo = 'bar'") { rows in
+                var iterator = rows.makeAsyncIterator()
+                let firstRow = try await iterator.next()
+                #expect(firstRow == nil)
             }
         }
     }

--- a/Tests/MySQLNIOTests/MySQLConnectionTests.swift
+++ b/Tests/MySQLNIOTests/MySQLConnectionTests.swift
@@ -22,9 +22,18 @@ struct MySQLConnectionTests {
         try await withTestMySQLServer { connection in
             try await connection.query("test") { rows in
                 var iterator = rows.makeAsyncIterator()
-                try #expect(await iterator.next() == "row1")
-                try #expect(await iterator.next() == "row2")
-                try #expect(await iterator.next() == "row3")
+
+                let firstRow = try #require(await iterator.next())
+                #expect(firstRow.columns.count == 1)
+                #expect(String(buffer: try #require(firstRow.first?.bytes)) == "row1")
+
+                let secondRow = try #require(await iterator.next())
+                #expect(secondRow.columns.count == 1)
+                #expect(String(buffer: try #require(secondRow.first?.bytes)) == "row2")
+
+                let thirdRow = try #require(await iterator.next())
+                #expect(thirdRow.columns.count == 1)
+                #expect(String(buffer: try #require(thirdRow.first?.bytes)) == "row3")
             }
         } server: { channel in
             let queryPacket = try await channel.waitForOutboundWrite(as: ByteBuffer.self)
@@ -32,12 +41,31 @@ struct MySQLConnectionTests {
             let queryString = queryPacket.getString(at: queryPacket.readerIndex + 5, length: queryPacket.readableBytes - 5)
             #expect(queryString == "test")
             let resultsetMetadataPacket = NIOAsyncTestingChannel.makeMySQLPacket(sequenceID: 1) { buffer in
-                buffer.writeInteger(0, as: UInt8.self)  // metadata doesn't follow
-                buffer.writeInteger(0, as: UInt8.self)  // column count
+                buffer.writeEncodedInteger(1, strategy: .mySQL)  // column count
+                // TODO: Fix crash when there is no column definitions (i.e. when `metadata_follows = 0`)
+                buffer.writeInteger(1, as: UInt8.self)  // metadata follows
             }
             try await channel.writeInbound(resultsetMetadataPacket)
+            let columnDefinitionPacket = NIOAsyncTestingChannel.makeMySQLPacket(sequenceID: 2) { buffer in
+                let columnDefinition = ColumnDefinition(
+                    schema: "schema",
+                    table: "table",
+                    orgTable: "orgTable",
+                    name: "name",
+                    orgName: "orgName",
+                    extendedMetadata: nil,
+                    characterSet: .utf8Unicode14AICI,
+                    columnLength: 255,
+                    dataType: .varchar,
+                    flags: 0,
+                    decimals: 0,
+                    format: .text
+                )
+                columnDefinition.write(to: &buffer, capabilities: .baselineClientCapabilities)
+            }
+            try await channel.writeInbound(columnDefinitionPacket)
             for (i, row) in ["row1", "row2", "row3"].enumerated() {
-                let rowPacket = NIOAsyncTestingChannel.makeMySQLPacket(sequenceID: 2 + UInt8(i)) { buffer in
+                let rowPacket = NIOAsyncTestingChannel.makeMySQLPacket(sequenceID: 3 + UInt8(i)) { buffer in
                     buffer.writeLengthPrefixedString(row, strategy: .mySQL)
                 }
                 try await channel.writeInbound(rowPacket)
@@ -50,7 +78,7 @@ struct MySQLConnectionTests {
                 info: nil,
                 sessionStateInfo: nil
             )
-            let okPacketBuffer = NIOAsyncTestingChannel.makeMySQLPacket(sequenceID: 5) { buffer in
+            let okPacketBuffer = NIOAsyncTestingChannel.makeMySQLPacket(sequenceID: 6) { buffer in
                 okPacket.write(to: &buffer, capabilities: .baselineClientCapabilities)
             }
             try await channel.writeInbound(okPacketBuffer)

--- a/Tests/MySQLNIOTests/MySQLNIOTests.swift
+++ b/Tests/MySQLNIOTests/MySQLNIOTests.swift
@@ -1,0 +1,49 @@
+import Testing
+
+@testable import MySQLNIO
+
+@Suite("MySQLNIO Tests")
+struct MySQLNIOTests {
+    @Test("Best Collation for Version")
+    func bestCollationForVersion() {
+        let mariaDBVersions: [String: MySQLCollation] = [
+            // MariaDB 10.9 or older
+            "9.0": .utf8Unicode52CI,
+            "10.0": .utf8Unicode52CI,
+            "10.6": .utf8Unicode52CI,
+            // MariaDB 10.10 or newer
+            "10.10": .utf8Unicode14AICI,
+            "10.11": .utf8Unicode14AICI,
+            "11.8": .utf8Unicode14AICI,
+            "12.3": .utf8Unicode14AICI,
+            "13.0": .utf8Unicode14AICI,
+            "14.0": .utf8Unicode14AICI,
+        ]
+
+        let mySQLVersions: [String: MySQLCollation] = [
+            // MySQL 5.7 or older
+            "5.0": .utf8Unicode52CI,
+            "5.7": .utf8Unicode52CI,
+            "6.0": .utf8Unicode52CI,
+            "7.0": .utf8Unicode52CI,
+            // MySQL 8.0 or newer
+            "8.4": .utf8Unicode9AICI,
+            "9.7": .utf8Unicode9AICI,
+            "10.0": .utf8Unicode9AICI,
+            "11.0": .utf8Unicode9AICI,
+            "26.7": .utf8Unicode9AICI,
+            "27.0": .utf8Unicode9AICI,
+            "28.0": .utf8Unicode9AICI,
+            "30.0": .utf8Unicode9AICI,
+        ]
+
+        for (version, expectedCollation) in mariaDBVersions {
+            let actualCollation = MySQLCollation.bestCollation(forVersion: version, capabilities: .init())
+            #expect(actualCollation == expectedCollation, "Expected \(expectedCollation) for MariaDB version \(version), but got \(actualCollation)")
+        }
+        for (version, expectedCollation) in mySQLVersions {
+            let actualCollation = MySQLCollation.bestCollation(forVersion: version, capabilities: .clientMySQL)
+            #expect(actualCollation == expectedCollation, "Expected \(expectedCollation) for MySQL version \(version), but got \(actualCollation)")
+        }
+    }
+}

--- a/Tests/MySQLNIOTests/MySQLPacketsTests.swift
+++ b/Tests/MySQLNIOTests/MySQLPacketsTests.swift
@@ -184,12 +184,6 @@ struct MySQLPacketsTests {
     }
 }
 
-extension MySQLCollation: Equatable {
-    static func == (lhs: MySQLCollation, rhs: MySQLCollation) -> Bool {
-        lhs.id == rhs.id
-    }
-}
-
 extension InitialHandshakePacket: Equatable {
     static func == (lhs: InitialHandshakePacket, rhs: InitialHandshakePacket) -> Bool {
         lhs.protocolVersion == rhs.protocolVersion && lhs.serverVersion == rhs.serverVersion && lhs.connectionID == rhs.connectionID

--- a/Tests/MySQLNIOTests/MySQLPacketsTests.swift
+++ b/Tests/MySQLNIOTests/MySQLPacketsTests.swift
@@ -71,7 +71,7 @@ struct MySQLPacketsTests {
             let handshakeResponse = HandshakeResponsePacket(
                 clientCapabilities: capabilities,
                 maxPacketSize: 0x4000_0000,
-                clientDefaultCharacterSetAndCollation: .init(name: "latin1_swedish_ci", characterSetName: "latin1", id: 8),
+                clientDefaultCharacterSetAndCollation: .init(name: "", characterSetName: "", id: 8),
                 username: "root",
                 authResponse: .init(
                     bytes: [0x22, 0x50, 0x79, 0xa2, 0x12, 0xd4, 0xe8, 0x82, 0xe5, 0xb3, 0xf4, 0x1a, 0x97, 0x75, 0x6b, 0xc8, 0xbe, 0xdb, 0x9f, 0x80]


### PR DESCRIPTION
Updates the `query` API to be more similar to PostgresNIO's

- `MySQLRowSequence` for now it's basically just a wrapper around `AsyncThrowingStream<MySQLRow, any Error>`
- I've implemented `MySQLRandomAccessRow`, but right now it's no different from `MySQLRow` since the lookup table gets created for all `MySQLRow`s in the state machine
- The MySQL protocol does not guarantee that column metadata is sent, but the `MySQLRow`/`MySQLCell` API currently does so, and when it is not sent, it crashes due to an out-of-bounds index error