### PR TITLE
Fix graceful shutdown, cancellation and other stuff

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Check out package
         uses: actions/checkout@v7
       - name: Run unit tests
-        run: swift test --enable-code-coverage --no-parallel
+        run: swift test --enable-code-coverage
       - name: Upload code coverage
         uses: vapor/swift-codecov-action@2f478f2fd22e06ca363967d0fb6c6593a8548cee # v0.3.5
         with:
@@ -109,7 +109,7 @@ jobs:
         uses: actions/checkout@v7
         with: { path: 'mysql-nio' }
       - name: Run unit tests
-        run: swift test --package-path mysql-nio --enable-code-coverage --no-parallel
+        run: swift test --package-path mysql-nio --enable-code-coverage
       - name: Upload code coverage
         uses: vapor/swift-codecov-action@2f478f2fd22e06ca363967d0fb6c6593a8548cee # v0.3.5
         with:
@@ -169,7 +169,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v7
       - name: Run all tests
-        run: swift test --enable-code-coverage --no-parallel
+        run: swift test --enable-code-coverage
       - name: Upload code coverage
         uses: vapor/swift-codecov-action@2f478f2fd22e06ca363967d0fb6c6593a8548cee # v0.3.5
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Check out package
         uses: actions/checkout@v7
       - name: Run unit tests
-        run: swift test --enable-code-coverage
+        run: swift test --enable-code-coverage --no-parallel
       - name: Upload code coverage
         uses: vapor/swift-codecov-action@2f478f2fd22e06ca363967d0fb6c6593a8548cee # v0.3.5
         with:
@@ -109,7 +109,7 @@ jobs:
         uses: actions/checkout@v7
         with: { path: 'mysql-nio' }
       - name: Run unit tests
-        run: swift test --package-path mysql-nio --enable-code-coverage
+        run: swift test --package-path mysql-nio --enable-code-coverage --no-parallel
       - name: Upload code coverage
         uses: vapor/swift-codecov-action@2f478f2fd22e06ca363967d0fb6c6593a8548cee # v0.3.5
         with:
@@ -169,7 +169,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v7
       - name: Run all tests
-        run: swift test --enable-code-coverage
+        run: swift test --enable-code-coverage --no-parallel
       - name: Upload code coverage
         uses: vapor/swift-codecov-action@2f478f2fd22e06ca363967d0fb6c6593a8548cee # v0.3.5
         with:

--- a/Sources/MySQLNIO/Connection/MySQLChannelHandler+stateMachine.swift
+++ b/Sources/MySQLNIO/Connection/MySQLChannelHandler+stateMachine.swift
@@ -27,6 +27,7 @@ extension MySQLChannelHandler {
             let context: Context
             let connectPromise: PendingCommand
             let configuration: MySQLConnectionConfiguration
+            var gracefulShutdown: Bool
         }
 
         /// See ``MySQLChannelHandler/StateMachine/State/awaitingAuthReply-enum.case``.
@@ -37,6 +38,7 @@ extension MySQLChannelHandler {
             let capabilities: MySQLCapabilities
             var authMethod: any AuthenticationMethod & ~Copyable
             let password: String?
+            var gracefulShutdown: Bool
         }
 
         @usableFromInline
@@ -92,7 +94,9 @@ extension MySQLChannelHandler {
         mutating func setAwaitingGreeting(context: Context, connectPromise: PendingCommand, configuration: MySQLConnectionConfiguration) {
             switch consume self.state {
             case .startup:
-                self = .awaitingGreeting(.init(context: context, connectPromise: connectPromise, configuration: configuration))
+                self = .awaitingGreeting(
+                    .init(context: context, connectPromise: connectPromise, configuration: configuration, gracefulShutdown: false)
+                )
             case .awaitingGreeting:
                 preconditionFailure("Cannot set awaitingGreeting state when state is already awaitingGreeting")
             case .awaitingAuthReply:
@@ -288,7 +292,8 @@ extension MySQLChannelHandler {
                             connectPromise: state.connectPromise,
                             capabilities: clientCapabilities,
                             authMethod: authMethod,
-                            password: state.configuration.password
+                            password: state.configuration.password,
+                            gracefulShutdown: state.gracefulShutdown
                         )
                     )
 
@@ -347,6 +352,10 @@ extension MySQLChannelHandler {
                     } catch {
                         self = .closed(error)
                         return .failPromise(state.connectPromise, error)
+                    }
+                    if state.gracefulShutdown {
+                        self = .closed(nil)
+                        return .succeedPromiseAndClose(state.connectPromise, statusFlags: okPacket.serverStatus)
                     }
                     self = .connected(.init(context: state.context, activeCommand: nil, pendingCommands: .init(), capabilities: state.capabilities))
                     return .succeedPromise(state.connectPromise, .cancel, nextCommand: nil, statusFlags: okPacket.serverStatus)
@@ -763,11 +772,13 @@ extension MySQLChannelHandler {
             case .startup:
                 self = .closed(nil)
                 return .doNothing
-            case .awaitingGreeting(let state):
-                self = .closing(.init(context: state.context, pendingCommands: .init([state.connectPromise]), capabilities: .requiredCapabilities))
+            case .awaitingGreeting(var state):
+                state.gracefulShutdown = true
+                self = .awaitingGreeting(state)
                 return .doNothing
-            case .awaitingAuthReply(let state):
-                self = .closing(.init(context: state.context, pendingCommands: .init([state.connectPromise]), capabilities: state.capabilities))
+            case .awaitingAuthReply(var state):
+                state.gracefulShutdown = true
+                self = .awaitingAuthReply(state)
                 return .doNothing
             case .connected(let state):
                 if state.activeCommand != nil || !state.pendingCommands.isEmpty {

--- a/Sources/MySQLNIO/Connection/MySQLChannelHandler+stateMachine.swift
+++ b/Sources/MySQLNIO/Connection/MySQLChannelHandler+stateMachine.swift
@@ -56,7 +56,7 @@ extension MySQLChannelHandler {
             /// > so it should only be used when we want to fail all pending commands and close the connection,
             /// > such as when a deadline is hit or a cancel is requested.
             mutating func allPendingCommands() -> Deque<PendingCommand> {
-                if let activeCommand { pendingCommands.append(activeCommand) }
+                if let activeCommand { pendingCommands.prepend(activeCommand) }
                 return pendingCommands
             }
 

--- a/Sources/MySQLNIO/Connection/MySQLChannelHandler+stateMachine.swift
+++ b/Sources/MySQLNIO/Connection/MySQLChannelHandler+stateMachine.swift
@@ -178,7 +178,7 @@ extension MySQLChannelHandler {
                 } else {
                     command.activateDeadline()
                     state.activeCommand = command
-                    self = .query(.init(connectedState: state, stateMachine: .init(capabilities: state.capabilities)))
+                    self = .query(.init(connectedState: state, stateMachine: .init(capabilities: state.capabilities), gracefulShutdown: false))
                     return .sendCommand(state.context, command)
                 }
             case .query(var state):
@@ -428,7 +428,7 @@ extension MySQLChannelHandler {
                     case .utility:
                         self = .connected(state)
                     case .query:
-                        self = .query(.init(connectedState: state, stateMachine: .init(capabilities: state.capabilities)))
+                        self = .query(.init(connectedState: state, stateMachine: .init(capabilities: state.capabilities), gracefulShutdown: false))
                     }
                     guard let deadline = nextCommand.deadline else {
                         preconditionFailure("The command deadline cannot be nil when the command is sent.")
@@ -469,7 +469,11 @@ extension MySQLChannelHandler {
                         state.connectedState.activeCommand = nextCommand
                         switch nextCommand.kind {
                         case .utility:
-                            self = .connected(state.connectedState)
+                            if state.gracefulShutdown {
+                                self = .closing(state.connectedState)
+                            } else {
+                                self = .connected(state.connectedState)
+                            }
                         case .query:
                             self = .query(state)
                         }
@@ -478,8 +482,13 @@ extension MySQLChannelHandler {
                         }
                         return .succeedPromise(command, .reschedule(deadline), nextCommand: nextCommand, statusFlags: nil)
                     } else {
-                        self = .connected(state.connectedState)
-                        return .succeedPromise(command, .cancel, nextCommand: nil, statusFlags: nil)
+                        if state.gracefulShutdown {
+                            self = .closed(nil)
+                            return .succeedPromiseAndClose(command, statusFlags: nil)
+                        } else {
+                            self = .connected(state.connectedState)
+                            return .succeedPromise(command, .cancel, nextCommand: nil, statusFlags: nil)
+                        }
                     }
                 case .moreResultsExists:
                     // TODO: handle multiple result sets
@@ -528,7 +537,18 @@ extension MySQLChannelHandler {
                     var nextCommand = nextCommand
                     nextCommand.activateDeadline()
                     state.activeCommand = nextCommand
-                    self = .closing(state)
+                    switch nextCommand.kind {
+                    case .utility:
+                        self = .closing(state)
+                    case .query:
+                        self = .query(
+                            .init(
+                                connectedState: state,
+                                stateMachine: .init(capabilities: state.capabilities),
+                                gracefulShutdown: true
+                            )
+                        )
+                    }
                     guard let deadline = nextCommand.deadline else {
                         preconditionFailure("The command deadline cannot be nil when the command is sent.")
                     }
@@ -757,9 +777,10 @@ extension MySQLChannelHandler {
                     self = .closed(nil)
                     return .closeConnection(state.context)
                 }
-            case .query(let state):
+            case .query(var state):
                 if state.connectedState.activeCommand != nil || !state.connectedState.pendingCommands.isEmpty {
-                    self = .closing(state.connectedState)
+                    state.gracefulShutdown = true
+                    self = .query(state)
                     return .doNothing
                 } else {
                     self = .closed(nil)
@@ -840,6 +861,8 @@ extension MySQLChannelHandler.StateMachine {
     struct QueryState: ~Copyable {
         var connectedState: ConnectedState
         var stateMachine: QueryStateMachine
+        /// Whether a graceful shutdown has been requested.
+        var gracefulShutdown: Bool
     }
 
     @usableFromInline

--- a/Sources/MySQLNIO/Connection/MySQLChannelHandler+stateMachine.swift
+++ b/Sources/MySQLNIO/Connection/MySQLChannelHandler+stateMachine.swift
@@ -215,11 +215,15 @@ extension MySQLChannelHandler {
         enum ReceivedResponseAction {
             case handshakeRespond(ByteBuffer, sslRequest: ByteBuffer?, statusFlags: ServerStatusFlags)
             case authRespond(ByteBuffer?)
+            // TODO: why can statusFlags be nil here? Shouldn't it always be present in the OK packet?
             case succeedPromise(PendingCommand, DeadlineCallbackAction, nextCommand: PendingCommand?, statusFlags: ServerStatusFlags?)
             case succeedPromiseAndClose(PendingCommand, statusFlags: ServerStatusFlags?)
             case failPromise(PendingCommand, any Error)
             case closeWithError(any Error)
             case doNothing
+            case succeedQueryPromise(PendingCommand, statusFlags: ServerStatusFlags?)
+            case finishRowSequence(DeadlineCallbackAction, nextCommand: PendingCommand?, statusFlags: ServerStatusFlags?)
+            case finishRowSequenceAndClose(statusFlags: ServerStatusFlags?)
         }
 
         @usableFromInline
@@ -450,18 +454,39 @@ extension MySQLChannelHandler {
                 case .doNothing:
                     self = .query(state)
                     return .doNothing
-                case .columnMetadata(_):
-                    // TODO: handle column definitions
-                    self = .query(state)
-                    return .doNothing
-                case .row(let row):
+                case .moreResultsExists:
+                    // TODO: handle multiple result sets
                     guard case .query(let continuation) = state.connectedState.activeCommand?.kind else {
-                        preconditionFailure("The active command must be a query command when receiving rows.")
+                        preconditionFailure("The active command must be a query command when receiving the more results flag.")
                     }
-                    continuation.yield(row)
+                    continuation.finish()
                     self = .query(state)
                     return .doNothing
-                case .resultsetEnd:
+                // MARK: - `COM_QUERY` related actions
+                case .succeedPromise(_):
+                    // TODO: handle column definitions
+                    guard let command = state.connectedState.activeCommand else {
+                        preconditionFailure("Cannot complete query without an active command")
+                    }
+                    // The command's promise is resolved here,
+                    // so a later cancel while rows are still being read must not try to resolve it again;
+                    // only the row continuation matters now.
+                    state.connectedState.activeCommand?.promise = .forget
+                    self = .query(state)
+                    return .succeedQueryPromise(command, statusFlags: nil)
+                // TODO: check how we handle errors here and in the channel handler
+                case .failPromise(let error):
+                    guard let command = state.connectedState.activeCommand else {
+                        preconditionFailure("Cannot fail query without an active command")
+                    }
+                    guard case .query(let continuation) = command.kind else {
+                        preconditionFailure("The active command must be a query command when receiving an error.")
+                    }
+                    continuation.finish(throwing: error)
+                    state.connectedState.activeCommand = nil
+                    self = .connected(state.connectedState)
+                    return .failPromise(command, error)
+                case .noResultset:
                     guard let command = state.connectedState.activeCommand else {
                         preconditionFailure("Cannot complete query without an active command")
                     }
@@ -497,25 +522,55 @@ extension MySQLChannelHandler {
                             return .succeedPromise(command, .cancel, nextCommand: nil, statusFlags: nil)
                         }
                     }
-                case .moreResultsExists:
-                    // TODO: handle multiple result sets
+                // MARK: - `MySQLRowSequence` related actions
+                case .row(let row):
                     guard case .query(let continuation) = state.connectedState.activeCommand?.kind else {
-                        preconditionFailure("The active command must be a query command when receiving the more results flag.")
+                        preconditionFailure("The active command must be a query command when receiving rows.")
                     }
-                    continuation.finish()
+                    continuation.yield(row)
                     self = .query(state)
                     return .doNothing
-                case .error(let error):
-                    guard let command = state.connectedState.activeCommand else {
-                        preconditionFailure("Cannot fail query without an active command")
-                    }
-                    guard case .query(let continuation) = command.kind else {
+                case .rowError(let error):
+                    guard case .query(let continuation) = state.connectedState.activeCommand?.kind else {
                         preconditionFailure("The active command must be a query command when receiving an error.")
                     }
                     continuation.finish(throwing: error)
                     state.connectedState.activeCommand = nil
                     self = .connected(state.connectedState)
-                    return .failPromise(command, error)
+                    return .doNothing
+                case .resultsetEnd:
+                    guard case .query(let continuation) = state.connectedState.activeCommand?.kind else {
+                        preconditionFailure("The active command must be a query command when receiving the end of the result set.")
+                    }
+                    continuation.finish()
+                    state.connectedState.activeCommand = nil
+                    if let nextCommand = state.connectedState.pendingCommands.popFirst() {
+                        var nextCommand = nextCommand
+                        nextCommand.activateDeadline()
+                        state.connectedState.activeCommand = nextCommand
+                        switch nextCommand.kind {
+                        case .utility:
+                            if state.gracefulShutdown {
+                                self = .closing(state.connectedState)
+                            } else {
+                                self = .connected(state.connectedState)
+                            }
+                        case .query:
+                            self = .query(state)
+                        }
+                        guard let deadline = nextCommand.deadline else {
+                            preconditionFailure("The command deadline cannot be nil when the command is sent.")
+                        }
+                        return .finishRowSequence(.reschedule(deadline), nextCommand: nextCommand, statusFlags: nil)
+                    } else {
+                        if state.gracefulShutdown {
+                            self = .closed(nil)
+                            return .finishRowSequenceAndClose(statusFlags: nil)
+                        } else {
+                            self = .connected(state.connectedState)
+                            return .finishRowSequence(.cancel, nextCommand: nil, statusFlags: nil)
+                        }
+                    }
                 }
             case .closing(var state):
                 guard let command = state.activeCommand else {
@@ -854,11 +909,16 @@ extension MySQLChannelHandler.StateMachine {
     struct QueryStateMachine: ~Copyable {
         @usableFromInline
         enum State: ~Copyable {
+            // MARK: - `COM_QUERY` related states, see below for related actions
+
             /// A `COM_QUERY` command was sent and no response has yet been received, or a new
             /// resultset has been signaled as incoming but not yet received.
             case awaitingResultsetStart
             /// Waiting for one or more column metadata packets
             case awaitingColumnMetadata(columnsRemaining: UInt64, columnMetadata: ColumnMetadata)
+
+            // MARK: - `MySQLRowSequence` related states, see below for related actions
+
             /// Reading resultset rows
             case readingRows(columnMetadata: ColumnMetadata)
             /// All result sets received, or error stopped the query.
@@ -889,58 +949,74 @@ extension MySQLChannelHandler.StateMachine {
         @usableFromInline
         enum ReceivedResponseAction {
             case doNothing
-            case columnMetadata(ColumnMetadata)
-            case row(MySQLRow)
-            case resultsetEnd
+            /// TODO: handle multiple result sets
             case moreResultsExists
-            case error(any Error)
+
+            // MARK: - `COM_QUERY` related actions
+
+            /// The query command was received by the server and all column metadata has been received
+            case succeedPromise(ColumnMetadata?)
+            /// Something went wrong while sending the query command or receiving column metadata
+            case failPromise(any Error)
+            /// The query was successful but no rows were returned (e.g. an `UPDATE` command)
+            case noResultset
+
+            // MARK: - `MySQLRowSequence` related actions
+
+            /// Yield a row to the query continuation
+            case row(MySQLRow)
+            /// Send an error to the query continuation and finish it
+            case rowError(any Error)
+            /// Finish the query continuation
+            case resultsetEnd
         }
 
         @usableFromInline
         mutating func receivedResponse(packet: inout ByteBuffer) -> ReceivedResponseAction {
-            if packet.isErrorPacket {
-                guard let errorPacket = ErrorPacket(from: &packet), case .error(let errorKind) = errorPacket.kind else {
-                    let error = MySQLClientError.errorPacket()
-                    self = .done(result: error, capabilities: self.capabilities)
-                    return .error(error)
-                }
-                let error = MySQLClientError.errorPacket(errorCode: errorPacket.errorCode, errorMessage: errorKind.errorMessage)
-                self = .done(result: error, capabilities: self.capabilities)
-                return .error(error)
-            }
             switch consume self.state {
+            // MARK: - `COM_QUERY` related states
             case .awaitingResultsetStart:
+                guard !packet.isErrorPacket else {
+                    guard let errorPacket = ErrorPacket(from: &packet), case .error(let errorKind) = errorPacket.kind else {
+                        let error = MySQLClientError.errorPacket()
+                        self = .done(result: error, capabilities: self.capabilities)
+                        return .failPromise(error)
+                    }
+                    let error = MySQLClientError.errorPacket(errorCode: errorPacket.errorCode, errorMessage: errorKind.errorMessage)
+                    self = .done(result: error, capabilities: self.capabilities)
+                    return .failPromise(error)
+                }
                 if packet.isOKPacket(capabilities: self.capabilities) {
                     guard let okPacket = try? OKPacket(from: &packet, capabilities: self.capabilities) else {
                         let error = MySQLClientError.invalidPacket("Received an invalid OK Packet")
                         self = .done(result: error, capabilities: self.capabilities)
-                        return .error(error)
+                        return .failPromise(error)
                     }
                     if okPacket.serverStatus.contains(.serverMoreResultsExists) {
                         self = .awaitingResultsetStart(capabilities: self.capabilities)
                         return .moreResultsExists
                     }
                     self = .done(result: nil, capabilities: self.capabilities)
-                    return .resultsetEnd
+                    return .noResultset
                 }
                 guard let columnCount = packet.readEncodedInteger(as: UInt64.self, strategy: .mySQL) else {
                     let error = MySQLClientError.invalidPacket("Received an invalid Result Set Header Packet")
                     self = .done(result: error, capabilities: self.capabilities)
-                    return .error(error)
+                    return .failPromise(error)
                 }
                 var metadataFollows = false
                 if self.capabilities.metadataFlagAvailable {
                     guard let metadataFollowsFlag = packet.readInteger(as: UInt8.self) else {
                         let error = MySQLClientError.invalidPacket("Received an invalid Result Set Header Packet")
                         self = .done(result: error, capabilities: self.capabilities)
-                        return .error(error)
+                        return .failPromise(error)
                     }
                     metadataFollows = metadataFollowsFlag == 1
                 }
                 if !self.capabilities.metadataFlagAvailable || metadataFollows {
                     if columnCount == 0 {
                         self = .readingRows(columnMetadata: .init(), capabilities: self.capabilities)
-                        return .doNothing
+                        return .succeedPromise(nil)
                     } else {
                         self = .awaitingColumnMetadata(
                             columnsRemaining: columnCount,
@@ -951,20 +1027,30 @@ extension MySQLChannelHandler.StateMachine {
                     }
                 } else {
                     self = .readingRows(columnMetadata: .init(), capabilities: self.capabilities)
-                    return .doNothing
+                    return .succeedPromise(nil)
                 }
             case .awaitingColumnMetadata(let columnsRemaining, var columnMetadata):
+                guard !packet.isErrorPacket else {
+                    guard let errorPacket = ErrorPacket(from: &packet), case .error(let errorKind) = errorPacket.kind else {
+                        let error = MySQLClientError.errorPacket()
+                        self = .done(result: error, capabilities: self.capabilities)
+                        return .failPromise(error)
+                    }
+                    let error = MySQLClientError.errorPacket(errorCode: errorPacket.errorCode, errorMessage: errorKind.errorMessage)
+                    self = .done(result: error, capabilities: self.capabilities)
+                    return .failPromise(error)
+                }
                 guard let columnDefinition = ColumnDefinition(from: &packet, capabilities: self.capabilities, format: .text) else {
                     let error = MySQLClientError.invalidPacket("Received an invalid Column Definition Packet")
                     self = .done(result: error, capabilities: self.capabilities)
-                    return .error(error)
+                    return .failPromise(error)
                 }
                 let nextColumnIndex = columnMetadata.columns.count
                 columnMetadata.columns.append(columnDefinition)
                 columnMetadata.lookupTable[columnDefinition.name] = nextColumnIndex
                 if columnsRemaining == 1 {
                     self = .readingRows(columnMetadata: columnMetadata, capabilities: self.capabilities)
-                    return .columnMetadata(columnMetadata)
+                    return .succeedPromise(columnMetadata)
                 } else {
                     self = .awaitingColumnMetadata(
                         columnsRemaining: columnsRemaining - 1,
@@ -973,12 +1059,23 @@ extension MySQLChannelHandler.StateMachine {
                     )
                     return .doNothing
                 }
+            // MARK: - `MySQLRowSequence` related states
             case .readingRows(let columnMetadata):
+                guard !packet.isErrorPacket else {
+                    guard let errorPacket = ErrorPacket(from: &packet), case .error(let errorKind) = errorPacket.kind else {
+                        let error = MySQLClientError.errorPacket()
+                        self = .done(result: error, capabilities: self.capabilities)
+                        return .rowError(error)
+                    }
+                    let error = MySQLClientError.errorPacket(errorCode: errorPacket.errorCode, errorMessage: errorKind.errorMessage)
+                    self = .done(result: error, capabilities: self.capabilities)
+                    return .rowError(error)
+                }
                 if packet.isEOFPacket {
                     guard let eofPacket = EOFPacket(from: &packet) else {
                         let error = MySQLClientError.invalidPacket("Received an invalid EOF Packet")
                         self = .done(result: error, capabilities: self.capabilities)
-                        return .error(error)
+                        return .rowError(error)
                     }
                     if eofPacket.serverStatus.contains(.serverMoreResultsExists) {
                         self = .awaitingResultsetStart(capabilities: self.capabilities)
@@ -990,7 +1087,7 @@ extension MySQLChannelHandler.StateMachine {
                     guard let okPacket = try? OKPacket(from: &packet, capabilities: self.capabilities) else {
                         let error = MySQLClientError.invalidPacket("Received an invalid OK Packet")
                         self = .done(result: error, capabilities: self.capabilities)
-                        return .error(error)
+                        return .rowError(error)
                     }
                     if okPacket.serverStatus.contains(.serverMoreResultsExists) {
                         self = .awaitingResultsetStart(capabilities: self.capabilities)

--- a/Sources/MySQLNIO/Connection/MySQLChannelHandler+stateMachine.swift
+++ b/Sources/MySQLNIO/Connection/MySQLChannelHandler+stateMachine.swift
@@ -27,6 +27,7 @@ extension MySQLChannelHandler {
             let context: Context
             let connectPromise: PendingCommand
             let configuration: MySQLConnectionConfiguration
+            /// Whether a graceful shutdown has been requested.
             var gracefulShutdown: Bool
         }
 
@@ -38,6 +39,7 @@ extension MySQLChannelHandler {
             let capabilities: MySQLCapabilities
             var authMethod: any AuthenticationMethod & ~Copyable
             let password: String?
+            /// Whether a graceful shutdown has been requested.
             var gracefulShutdown: Bool
         }
 
@@ -501,11 +503,7 @@ extension MySQLChannelHandler {
                         state.connectedState.activeCommand = nextCommand
                         switch nextCommand.kind {
                         case .utility:
-                            if state.gracefulShutdown {
-                                self = .closing(state.connectedState)
-                            } else {
-                                self = .connected(state.connectedState)
-                            }
+                            self = state.gracefulShutdown ? .closing(state.connectedState) : .connected(state.connectedState)
                         case .query:
                             self = .query(state)
                         }
@@ -550,11 +548,7 @@ extension MySQLChannelHandler {
                         state.connectedState.activeCommand = nextCommand
                         switch nextCommand.kind {
                         case .utility:
-                            if state.gracefulShutdown {
-                                self = .closing(state.connectedState)
-                            } else {
-                                self = .connected(state.connectedState)
-                            }
+                            self = state.gracefulShutdown ? .closing(state.connectedState) : .connected(state.connectedState)
                         case .query:
                             self = .query(state)
                         }

--- a/Sources/MySQLNIO/Connection/MySQLChannelHandler+stateMachine.swift
+++ b/Sources/MySQLNIO/Connection/MySQLChannelHandler+stateMachine.swift
@@ -60,24 +60,22 @@ extension MySQLChannelHandler {
                 return pendingCommands
             }
 
-            func cancel(requestID: Int) -> (cancel: [PendingCommand], connectionClosedDueToCancellation: [PendingCommand]) {
-                var withRequestID = [PendingCommand]()
-                var withoutRequestID = [PendingCommand]()
-                if let activeCommand {
-                    if activeCommand.requestID == requestID {
-                        withRequestID.append(activeCommand)
-                    } else {
-                        withoutRequestID.append(activeCommand)
-                    }
+            /// Cancels the command with the given `requestID`, if any, without affecting other commands.
+            ///
+            /// - If the command is still pending (not yet sent), it is removed from the queue and returned so its promise can be failed.
+            /// - If the command is the active one (already sent, response in flight), its promise is replaced with `.forget` so the
+            ///   eventual response is discarded instead of double-resolving it; the original command is returned so its promise can be failed.
+            mutating func cancel(requestID: Int) -> CancelAction {
+                if var activeCommand, activeCommand.requestID == requestID {
+                    let cancelledCommand = activeCommand
+                    activeCommand.promise = .forget
+                    self.activeCommand = activeCommand
+                    return .cancelCommand(cancelledCommand)
                 }
-                for command in pendingCommands {
-                    if command.requestID == requestID {
-                        withRequestID.append(command)
-                    } else {
-                        withoutRequestID.append(command)
-                    }
+                if let index = pendingCommands.firstIndex(where: { $0.requestID == requestID }) {
+                    return .cancelCommand(pendingCommands.remove(at: index))
                 }
-                return (withRequestID, withoutRequestID)
+                return .doNothing
             }
         }
 
@@ -703,7 +701,7 @@ extension MySQLChannelHandler {
 
         @usableFromInline
         enum CancelAction {
-            case failPendingCommandsAndClose(cancel: [PendingCommand], closeConnectionDueToCancel: [PendingCommand])
+            case cancelCommand(PendingCommand)
             case doNothing
         }
 
@@ -717,42 +715,18 @@ extension MySQLChannelHandler {
                 preconditionFailure("Cannot cancel while in awaitingGreeting state")
             case .awaitingAuthReply:
                 preconditionFailure("Cannot cancel while in awaitingAuthReply state")
-            case .connected(let state):
-                let (cancel, closeConnectionDueToCancel) = state.cancel(requestID: requestID)
-                if cancel.count > 0 {
-                    self = .closed(MySQLClientError.cancelled)
-                    return .failPendingCommandsAndClose(
-                        cancel: cancel,
-                        closeConnectionDueToCancel: closeConnectionDueToCancel
-                    )
-                } else {
-                    self = .connected(state)
-                    return .doNothing
-                }
-            case .query(let state):
-                let (cancel, closeConnectionDueToCancel) = state.connectedState.cancel(requestID: requestID)
-                if cancel.count > 0 {
-                    self = .closed(MySQLClientError.cancelled)
-                    return .failPendingCommandsAndClose(
-                        cancel: cancel,
-                        closeConnectionDueToCancel: closeConnectionDueToCancel
-                    )
-                } else {
-                    self = .query(state)
-                    return .doNothing
-                }
-            case .closing(let state):
-                let (cancel, closeConnectionDueToCancel) = state.cancel(requestID: requestID)
-                if cancel.count > 0 {
-                    self = .closed(MySQLClientError.cancelled)
-                    return .failPendingCommandsAndClose(
-                        cancel: cancel,
-                        closeConnectionDueToCancel: closeConnectionDueToCancel
-                    )
-                } else {
-                    self = .closing(state)
-                    return .doNothing
-                }
+            case .connected(var state):
+                let action = state.cancel(requestID: requestID)
+                self = .connected(state)
+                return action
+            case .query(var state):
+                let action = state.connectedState.cancel(requestID: requestID)
+                self = .query(state)
+                return action
+            case .closing(var state):
+                let action = state.cancel(requestID: requestID)
+                self = .closing(state)
+                return action
             case .closed(let error):
                 self = .closed(error)
                 return .doNothing

--- a/Sources/MySQLNIO/Connection/MySQLChannelHandler.swift
+++ b/Sources/MySQLNIO/Connection/MySQLChannelHandler.swift
@@ -244,6 +244,16 @@ final class MySQLChannelHandler: ChannelDuplexHandler {
         case .failPromise(let command, let error):
             command.promise.fail(error)
             throw error
+        case .succeedQueryPromise(let command, let statusFlags):
+            if let statusFlags { self.statusFlags = statusFlags }
+            command.promise.succeed(packet)
+        case .finishRowSequence(let action, let nextCommand, let statusFlags):
+            self.processDeadlineCallbackAction(action: action)
+            if let nextCommand { _ = context.channel.writeAndFlush(nextCommand.packet) }
+            if let statusFlags { self.statusFlags = statusFlags }
+        case .finishRowSequenceAndClose(let statusFlags):
+            if let statusFlags { self.statusFlags = statusFlags }
+            context.close(promise: nil)
         case .doNothing:
             break
         }

--- a/Sources/MySQLNIO/Connection/MySQLChannelHandler.swift
+++ b/Sources/MySQLNIO/Connection/MySQLChannelHandler.swift
@@ -19,7 +19,7 @@ final class MySQLChannelHandler: ChannelDuplexHandler {
         @usableFromInline
         let packet: ByteBuffer?
         @usableFromInline
-        let promise: MySQLPromise<ByteBuffer>
+        var promise: MySQLPromise<ByteBuffer>
         @usableFromInline
         let requestID: Int
         /// Optional because in the connect promise we set the deadline directly.
@@ -198,13 +198,8 @@ final class MySQLChannelHandler: ChannelDuplexHandler {
     func cancel(requestID: Int) {
         self.eventLoop.assertInEventLoop()
         switch self.stateMachine.cancel(requestID: requestID) {
-        case .failPendingCommandsAndClose(let cancelled, let closeConnectionDueToCancel):
-            for command in cancelled {
-                command.promise.fail(MySQLClientError.cancelled)
-            }
-            for command in closeConnectionDueToCancel {
-                command.promise.fail(MySQLClientError.connectionClosedDueToCancellation)
-            }
+        case .cancelCommand(let command):
+            command.promise.fail(MySQLClientError.cancelled)
         case .doNothing:
             break
         }

--- a/Sources/MySQLNIO/Connection/MySQLChannelHandler.swift
+++ b/Sources/MySQLNIO/Connection/MySQLChannelHandler.swift
@@ -245,7 +245,7 @@ final class MySQLChannelHandler: ChannelDuplexHandler {
         case .succeedPromiseAndClose(let command, let statusFlags):
             if let statusFlags { self.statusFlags = statusFlags }
             command.promise.succeed(packet)
-            throw MySQLClientError.connectionClosing
+            context.close(promise: nil)
         case .failPromise(let command, let error):
             command.promise.fail(error)
             throw error

--- a/Sources/MySQLNIO/Connection/MySQLConnection.swift
+++ b/Sources/MySQLNIO/Connection/MySQLConnection.swift
@@ -168,7 +168,9 @@ extension MySQLConnection {
 
     /// Send a `COM_QUIT` command to the server to close the connection.
     func quit() throws {
-        _ = try self.channelHandler.sendUtilityCommandNoWait(.init(bytes: [0x00, 0x00, 0x00, 0x00, 0x01]))
+        if channel.isActive {
+            try self.channelHandler.sendUtilityCommandNoWait(.init(bytes: [0x00, 0x00, 0x00, 0x00, 0x01]))
+        }
     }
 
     private static func _makeConnection(

--- a/Sources/MySQLNIO/Connection/MySQLConnection.swift
+++ b/Sources/MySQLNIO/Connection/MySQLConnection.swift
@@ -76,7 +76,7 @@ public final actor MySQLConnection: Sendable {
         }
         self.channel.eventLoop.execute {
             self.assumeIsolated {
-                try? $0.triggerGracefulShutdown()
+                try? $0.quit()
                 $0.channel.close(mode: .all, promise: nil)
             }
         }
@@ -162,9 +162,13 @@ extension MySQLConnection {
     /// Trigger graceful shutdown of connection
     ///
     /// The connection will wait until all pending commands have been processed before closing the connection.
-    func triggerGracefulShutdown() throws {
-        _ = try self.channelHandler.sendUtilityCommandNoWait(.init(bytes: [0x00, 0x00, 0x00, 0x00, 0x01]))
+    func triggerGracefulShutdown() {
         self.channelHandler.triggerGracefulShutdown()
+    }
+
+    /// Send a `COM_QUIT` command to the server to close the connection.
+    func quit() throws {
+        _ = try self.channelHandler.sendUtilityCommandNoWait(.init(bytes: [0x00, 0x00, 0x00, 0x00, 0x01]))
     }
 
     private static func _makeConnection(

--- a/Sources/MySQLNIO/MySQLClientError.swift
+++ b/Sources/MySQLNIO/MySQLClientError.swift
@@ -8,8 +8,6 @@ public struct MySQLClientError: Error, Sendable, Equatable {
             case errorPacket
             /// The Task was cancelled
             case cancelled
-            /// Connection closed because another command was cancelled.
-            case connectionClosedDueToCancellation
             /// Connection closed because it timed out while waiting for response packet
             case timeout
             /// The server's protocol version is too old or too new, or the server doesn't support the minimum required capabilities.
@@ -32,8 +30,6 @@ public struct MySQLClientError: Error, Sendable, Equatable {
         public static let errorPacket = Self(.errorPacket)
         /// The Task was cancelled
         public static let cancelled = Self(.cancelled)
-        /// Connection closed because another command was cancelled.
-        public static let connectionClosedDueToCancellation = Self(.connectionClosedDueToCancellation)
         /// Connection closed because it timed out while waiting for response packet
         public static let timeout = Self(.timeout)
         /// The server's protocol version is too old or too new, or the server doesn't support the minimum required capabilities.
@@ -104,9 +100,6 @@ public struct MySQLClientError: Error, Sendable, Equatable {
 
     /// The Task was cancelled
     public static let cancelled = Self(errorType: .cancelled)
-
-    /// Connection closed because another command was cancelled.
-    public static let connectionClosedDueToCancellation = Self(errorType: .connectionClosedDueToCancellation)
 
     /// Connection closed because it timed out while waiting for response packet
     public static let timeout = Self(errorType: .timeout)

--- a/Sources/MySQLNIO/Protocol/Packets/Generic Response Packets/ErrorPacket.swift
+++ b/Sources/MySQLNIO/Protocol/Packets/Generic Response Packets/ErrorPacket.swift
@@ -49,4 +49,31 @@ struct ErrorPacket {
             self.kind = .error(.init(sqlState: sqlState, errorMessage: errorMessage))
         }
     }
+
+    package init(errorCode: UInt16, kind: Kind) {
+        self.errorCode = errorCode
+        self.kind = kind
+    }
+
+    package func write(to packet: inout ByteBuffer) {
+        packet.writeInteger(UInt8(0xFF))
+        packet.writeInteger(errorCode, endianness: .little)
+        switch kind {
+        case .progressReporting(let progress):
+            packet.writeInteger(progress.stage)
+            packet.writeInteger(progress.maxStage)
+            packet.writeBytes([
+                UInt8((progress.progress >> 16) & 0xFF),
+                UInt8((progress.progress >> 8) & 0xFF),
+                UInt8(progress.progress & 0xFF),
+            ])
+            packet.writeLengthPrefixedString(progress.progressInfo, strategy: .mySQL)
+        case .error(let error):
+            if let sqlState = error.sqlState {
+                packet.writeInteger(UInt8(0x23))  // "#"
+                packet.writeString(sqlState)
+            }
+            packet.writeString(error.errorMessage)
+        }
+    }
 }

--- a/Tests/IntegrationTests/MySQLConnectionTests.swift
+++ b/Tests/IntegrationTests/MySQLConnectionTests.swift
@@ -146,6 +146,10 @@ struct MySQLConnectionTests {
         ) { connection in
             try await connection.ping()
         }
+        // The channel handler always caches the following error,
+        // after the connection is closed and just before the channel becomes inactive:
+        // `debug MySQLNIOTests: error=uncleanShutdown [MySQLNIO] MySQLChannelHandler: ERROR`
+        // TODO: Is it our fault or MySQL's?
     }
 
     static var sslContext: NIOSSLContext {

--- a/Tests/MySQLNIOTests/MySQLConnectionTests.swift
+++ b/Tests/MySQLNIOTests/MySQLConnectionTests.swift
@@ -310,50 +310,35 @@ struct MySQLConnectionTests {
         }
     }
 
-    @Test("Cancellation", .disabled("debugging"))
+    @Test("Cancellation")
     func cancellation() async throws {
-        let (stream, continuation) = AsyncStream<Void>.makeStream()
-        try await withTestMySQLServer { connection in
-            try await withThrowingTaskGroup { group in
-                group.addTask {
-                    await #expect(throws: MySQLClientError.cancelled) {
-                        // This will be sent and become the active command
-                        async let firstCommand: Void = connection.ping()
+        let channel = NIOAsyncTestingChannel()
+        let logger = Logger(label: #function).withLogLevel(.trace)
+        let configuration = MySQLConnectionConfiguration(username: "test_username")
+        let connection = try await MySQLConnection.setupChannelAndConnect(channel, configuration: configuration, logger: logger)
+        try await channel.processHandshake(configuration: configuration)
 
-                        try await Task.sleep(for: .milliseconds(100))
+        try await withThrowingTaskGroup { group in
+            group.addTask {
+                // This will be sent and become the active command
+                async let firstCommand: Void = connection.ping()
 
-                        // No need to process this second command from the server, as it will be cancelled before it is sent
-                        async let secondCommand: Void = connection.ping()
-                        _ = try await (firstCommand, secondCommand)
-                    }
-                }
+                try await Task.sleep(for: .milliseconds(100))
 
-                try await Task.sleep(for: .milliseconds(500))
-                // This is put in the command queue before the cancellation,
-                // but will not be cancelled and sent to the server after the first command is completed
-                async let thirdCommand: Void = connection.ping()
-
-                // Wait until the server is in the middle of processing the command
-                await stream.first { _ in true }
-                group.cancelAll()
-
-                // Even after cancellation, the server can still process the third command
-                try await thirdCommand
-
-                // The connection is still active so we can send more commands after the cancellation
-                await #expect(throws: Never.self) {
-                    try await connection.ping()
-                }
+                // No need to process this second command from the server, as it will be cancelled before it is sent
+                async let secondCommand: Void = connection.ping()
+                _ = try await (firstCommand, secondCommand)
             }
-        } server: { channel in
-            // Wait for all three commands to be sent
-            try await Task.sleep(for: .milliseconds(1000))
+            try await Task.sleep(for: .milliseconds(500))
+            // This is put in the command queue before the cancellation,
+            // but will not be cancelled and sent to the server after the first command is completed
+            async let thirdCommand: Void = connection.ping()
 
             let pingCommandPacket = try await channel.waitForOutboundWrite(as: ByteBuffer.self)
             #expect(pingCommandPacket == ByteBuffer(bytes: [0x01, 0x00, 0x00, 0x00, 0x0E]))
 
             // In the middle of processing the command, we cancel the task
-            continuation.yield()
+            group.cancelAll()
 
             // The server continues to process the command as it has no knowledge of the cancellation
             let okPacket = OKPacket(
@@ -376,9 +361,20 @@ struct MySQLConnectionTests {
 
             // This is the `thirdCommand` sent before the cancellation
             try await channel.processPing()
+            try await thirdCommand
+        }
 
-            // This is the command sent after everything
-            try await channel.processPing()
+        // The connection is still active so we can send more commands after the cancellation
+        await withThrowingTaskGroup { group in
+            group.addTask { try await connection.ping() }
+            group.addTask { try await channel.processPing() }
+            await #expect(throws: Never.self) { try await group.waitForAll() }
+        }
+
+        connection.close()
+        if channel.isActive {
+            let quitPacket = try await channel.waitForOutboundWrite(as: ByteBuffer.self)
+            #expect(quitPacket == ByteBuffer(bytes: [0x01, 0x00, 0x00, 0x00, 0x01]))
         }
     }
 

--- a/Tests/MySQLNIOTests/MySQLConnectionTests.swift
+++ b/Tests/MySQLNIOTests/MySQLConnectionTests.swift
@@ -310,7 +310,7 @@ struct MySQLConnectionTests {
         }
     }
 
-    @Test("Cancellation")
+    @Test("Cancellation", .disabled("debugging"))
     func cancellation() async throws {
         let (stream, continuation) = AsyncStream<Void>.makeStream()
         try await withTestMySQLServer { connection in

--- a/Tests/MySQLNIOTests/MySQLConnectionTests.swift
+++ b/Tests/MySQLNIOTests/MySQLConnectionTests.swift
@@ -303,6 +303,7 @@ struct MySQLConnectionTests {
             }
             try await channel.writeInbound(okPacketBuffer)
 
+            try await Task.sleep(for: .milliseconds(200))  // Wait for the graceful shutdown to complete
             #expect(!channel.isActive)
 
             try await channel.closeFuture.get()

--- a/Tests/MySQLNIOTests/MySQLConnectionTests.swift
+++ b/Tests/MySQLNIOTests/MySQLConnectionTests.swift
@@ -317,12 +317,12 @@ struct MySQLConnectionTests {
                 group.addTask {
                     await #expect(throws: MySQLClientError.cancelled) {
                         // This will be sent and become the active command
-                        async let firstCommand = connection.ping()
+                        async let firstCommand: Void = connection.ping()
 
                         try await Task.sleep(for: .milliseconds(50))
 
                         // No need to process this second command from the server, as it will be cancelled before it is sent
-                        async let secondCommand = connection.ping()
+                        async let secondCommand: Void = connection.ping()
                         _ = try await (firstCommand, secondCommand)
                     }
                 }
@@ -330,7 +330,7 @@ struct MySQLConnectionTests {
                 try await Task.sleep(for: .milliseconds(100))
                 // This is put in the command queue before the cancellation,
                 // but will not be cancelled and sent to the server after the first command is completed
-                async let thirdCommand = connection.ping()
+                async let thirdCommand: Void = connection.ping()
 
                 // Wait until the server is in the middle of processing the command
                 await stream.first { _ in true }

--- a/Tests/MySQLNIOTests/MySQLConnectionTests.swift
+++ b/Tests/MySQLNIOTests/MySQLConnectionTests.swift
@@ -319,7 +319,7 @@ struct MySQLConnectionTests {
                         // This will be sent and become the active command
                         async let firstCommand: Void = connection.ping()
 
-                        try await Task.sleep(for: .milliseconds(50))
+                        try await Task.sleep(for: .milliseconds(100))
 
                         // No need to process this second command from the server, as it will be cancelled before it is sent
                         async let secondCommand: Void = connection.ping()
@@ -327,7 +327,7 @@ struct MySQLConnectionTests {
                     }
                 }
 
-                try await Task.sleep(for: .milliseconds(100))
+                try await Task.sleep(for: .milliseconds(500))
                 // This is put in the command queue before the cancellation,
                 // but will not be cancelled and sent to the server after the first command is completed
                 async let thirdCommand: Void = connection.ping()
@@ -337,7 +337,7 @@ struct MySQLConnectionTests {
                 group.cancelAll()
 
                 // Even after cancellation, the server can still process the third command
-                _ = try await thirdCommand
+                try await thirdCommand
 
                 // The connection is still active so we can send more commands after the cancellation
                 await #expect(throws: Never.self) {
@@ -346,7 +346,7 @@ struct MySQLConnectionTests {
             }
         } server: { channel in
             // Wait for all three commands to be sent
-            try await Task.sleep(for: .milliseconds(150))
+            try await Task.sleep(for: .milliseconds(1000))
 
             let pingCommandPacket = try await channel.waitForOutboundWrite(as: ByteBuffer.self)
             #expect(pingCommandPacket == ByteBuffer(bytes: [0x01, 0x00, 0x00, 0x00, 0x0E]))

--- a/Tests/MySQLNIOTests/MySQLConnectionTests.swift
+++ b/Tests/MySQLNIOTests/MySQLConnectionTests.swift
@@ -59,4 +59,411 @@ struct MySQLConnectionTests {
             )
         }
     }
+
+    @Test("Row Error")
+    func rowError() async throws {
+        try await withTestMySQLServer { connection in
+            try await connection.query("test") { rows in
+                var iterator = rows.makeAsyncIterator()
+
+                let firstRow = try #require(await iterator.next())
+                #expect(firstRow.columns.count == 1)
+                #expect(String(buffer: try #require(firstRow.first?.bytes)) == "row1")
+
+                await #expect(throws: MySQLClientError.errorPacket(errorCode: 21, errorMessage: "test")) {
+                    try await iterator.next()
+                }
+            }
+        } server: { channel in
+            let queryPacket = try await channel.waitForOutboundWrite(as: ByteBuffer.self)
+            #expect(queryPacket.getBytes(at: queryPacket.readerIndex + 4, length: 1) == [0x03])  // COM_QUERY command
+            let queryString = queryPacket.getString(at: queryPacket.readerIndex + 5, length: queryPacket.readableBytes - 5)
+            #expect(queryString == "test")
+            let resultsetMetadataPacket = NIOAsyncTestingChannel.makeMySQLPacket(sequenceID: 1) { buffer in
+                buffer.writeEncodedInteger(1, strategy: .mySQL)  // column count
+                // TODO: Fix crash when there is no column definitions (i.e. when `metadata_follows = 0`)
+                buffer.writeInteger(1, as: UInt8.self)  // metadata follows
+            }
+            try await channel.writeInbound(resultsetMetadataPacket)
+            let columnDefinitionPacket = NIOAsyncTestingChannel.makeMySQLPacket(sequenceID: 2) { buffer in
+                let columnDefinition = ColumnDefinition(
+                    schema: "schema",
+                    table: "table",
+                    orgTable: "orgTable",
+                    name: "name",
+                    orgName: "orgName",
+                    extendedMetadata: nil,
+                    characterSet: .utf8Unicode14AICI,
+                    columnLength: 255,
+                    dataType: .varchar,
+                    flags: 0,
+                    decimals: 0,
+                    format: .text
+                )
+                columnDefinition.write(to: &buffer, capabilities: .baselineClientCapabilities)
+            }
+            try await channel.writeInbound(columnDefinitionPacket)
+            let row1Packet = NIOAsyncTestingChannel.makeMySQLPacket(sequenceID: 3) { buffer in
+                buffer.writeLengthPrefixedString("row1", strategy: .mySQL)
+            }
+            try await channel.writeInbound(row1Packet)
+
+            let errorPacket = ErrorPacket(errorCode: 21, kind: .error(.init(sqlState: nil, errorMessage: "test")))
+            let errorPacketBuffer = NIOAsyncTestingChannel.makeMySQLPacket(sequenceID: 4) { buffer in
+                errorPacket.write(to: &buffer)
+            }
+            try await channel.writeInbound(errorPacketBuffer)
+        }
+    }
+
+    @Test("Graceful Shutdown")
+    func gracefulShutdown() async throws {
+        let (receivedStream, receivedContinuation) = AsyncStream<Void>.makeStream()
+        let (shutdownStream, shutdownContinuation) = AsyncStream<Void>.makeStream()
+        try await withTestMySQLServer { connection in
+            async let response = connection.statistics()
+            await receivedStream.first { _ in true }
+            await connection.triggerGracefulShutdown()
+            shutdownContinuation.yield()
+            try await #expect(response == "Test")
+        } server: { channel in
+            let statisticsCommandPacket = try await channel.waitForOutboundWrite(as: ByteBuffer.self)
+            #expect(statisticsCommandPacket == ByteBuffer(bytes: [0x01, 0x00, 0x00, 0x00, 0x09]))
+
+            receivedContinuation.yield()
+            await shutdownStream.first { _ in true }
+            #expect(channel.isActive)
+
+            let response = NIOAsyncTestingChannel.makeMySQLPacket(sequenceID: 1) {
+                $0.writeString("Test")
+            }
+            try await channel.writeInbound(response)
+
+            #expect(!channel.isActive)
+
+            try await channel.closeFuture.get()
+        }
+    }
+
+    @Test("Graceful Shutdown during Handshake")
+    func gracefulShutdownDuringHandshake() async throws {
+        let channel = NIOAsyncTestingChannel()
+        let logger = Logger(label: #function).withLogLevel(.trace)
+        let configuration = MySQLConnectionConfiguration(username: "test_username")
+        let connection = try await MySQLConnection.setupChannelAndConnect(channel, configuration: configuration, logger: logger)
+
+        await connection.triggerGracefulShutdown()
+        #expect(channel.isActive)
+
+        let initialHandshakePacket = InitialHandshakePacket(
+            protocolVersion: 10,
+            serverVersion: "9.7.0",
+            connectionID: 12345,
+            serverCapabilities: .baselineClientCapabilities,
+            serverDefaultCollation: 255,
+            statusFlags: [.serverStatusAutocommit],
+            pluginDataLength: 21,
+            authenticationPluginData: ByteBuffer(
+                bytes: [
+                    0x01, 0x02, 0x03, 0x04, 0x05,
+                    0x06, 0x07, 0x08, 0x09, 0x0A,
+                    0x0B, 0x0C, 0x0D, 0x0E, 0x0F,
+                    0x10, 0x11, 0x12, 0x13, 0x14,
+                ]
+            ),
+            authenticationPluginName: "mysql_native_password"
+        )
+        let initialHandshakeBuffer = NIOAsyncTestingChannel.makeMySQLPacket(sequenceID: 0) {
+            initialHandshakePacket.write(to: &$0)
+        }
+        try await channel.writeInbound(initialHandshakeBuffer)
+
+        #expect(channel.isActive)
+
+        let responseBuffer = try await channel.waitForOutboundWrite(as: ByteBuffer.self)
+        let expectedBuffer = NIOAsyncTestingChannel.makeMySQLPacket(sequenceID: 1) {
+            let handshakeResponsePacket = HandshakeResponsePacket(
+                clientCapabilities: .baselineClientCapabilities,
+                maxPacketSize: .max,
+                clientDefaultCharacterSetAndCollation: .bestCollation(
+                    forVersion: "9.7.0",
+                    capabilities: .baselineClientCapabilities
+                ),
+                username: configuration.username,
+                authResponse: ByteBuffer(bytes: [
+                    0x14, 0x22, 0x50, 0x79, 0xa2, 0x12, 0xd4, 0xe8, 0x82, 0xe5, 0xb3, 0xf4, 0x1a, 0x97, 0x75, 0x6b, 0xc8, 0xbe, 0xdb, 0x9f,
+                ]),
+                defaultDatabaseName: configuration.defaultDatabaseName,
+                authenticationPluginName: "mysql_native_password",
+                connectionAttributes: configuration.connectionAttributes,
+                zstdCompressionLevel: nil
+            )
+            handshakeResponsePacket.write(to: &$0, capabilities: .baselineClientCapabilities, password: configuration.password != nil)
+        }
+        #expect(responseBuffer == expectedBuffer)
+
+        #expect(channel.isActive)
+
+        let okPacket = OKPacket(
+            affectedRows: 0,
+            lastInsertID: 0,
+            serverStatus: [],
+            warningCount: 0,
+            info: "",
+            newSchema: nil,
+            updatedSettings: [:],
+            generalStateChange: false
+        )
+        let okPacketBuffer = NIOAsyncTestingChannel.makeMySQLPacket(sequenceID: 2) {
+            okPacket.write(to: &$0, capabilities: .baselineClientCapabilities)
+        }
+        try await channel.writeInbound(okPacketBuffer)
+
+        #expect(!channel.isActive)
+
+        // The connection was already closed by the graceful shutdown, so this is a no-op and no COM_QUIT is sent.
+        connection.close()
+
+        try await channel.closeFuture.get()
+    }
+
+    @Test("Graceful Shutdown during Query")
+    func gracefulShutdownDuringQuery() async throws {
+        try await withTestMySQLServer { connection in
+            try await connection.query("test") { rows in
+                var iterator = rows.makeAsyncIterator()
+
+                let firstRow = try #require(await iterator.next())
+                #expect(firstRow.columns.count == 1)
+                #expect(String(buffer: try #require(firstRow.first?.bytes)) == "row1")
+
+                // Trigger graceful shutdown mid query, which will close the connection after the current command is completed
+                await connection.triggerGracefulShutdown()
+
+                let secondRow = try #require(await iterator.next())
+                #expect(secondRow.columns.count == 1)
+                #expect(String(buffer: try #require(secondRow.first?.bytes)) == "row2")
+            }
+
+            await #expect(throws: MySQLClientError.connectionClosed) {
+                try await connection.ping()
+            }
+        } server: { channel in
+            let queryPacket = try await channel.waitForOutboundWrite(as: ByteBuffer.self)
+            #expect(queryPacket.getBytes(at: queryPacket.readerIndex + 4, length: 1) == [0x03])  // COM_QUERY command
+            let queryString = queryPacket.getString(at: queryPacket.readerIndex + 5, length: queryPacket.readableBytes - 5)
+            #expect(queryString == "test")
+            let resultsetMetadataPacket = NIOAsyncTestingChannel.makeMySQLPacket(sequenceID: 1) { buffer in
+                buffer.writeEncodedInteger(1, strategy: .mySQL)  // column count
+                // TODO: Fix crash when there is no column definitions (i.e. when `metadata_follows = 0`)
+                buffer.writeInteger(1, as: UInt8.self)  // metadata follows
+            }
+            try await channel.writeInbound(resultsetMetadataPacket)
+            let columnDefinitionPacket = NIOAsyncTestingChannel.makeMySQLPacket(sequenceID: 2) { buffer in
+                let columnDefinition = ColumnDefinition(
+                    schema: "schema",
+                    table: "table",
+                    orgTable: "orgTable",
+                    name: "name",
+                    orgName: "orgName",
+                    extendedMetadata: nil,
+                    characterSet: .utf8Unicode14AICI,
+                    columnLength: 255,
+                    dataType: .varchar,
+                    flags: 0,
+                    decimals: 0,
+                    format: .text
+                )
+                columnDefinition.write(to: &buffer, capabilities: .baselineClientCapabilities)
+            }
+            try await channel.writeInbound(columnDefinitionPacket)
+            let row1Packet = NIOAsyncTestingChannel.makeMySQLPacket(sequenceID: 3) { buffer in
+                buffer.writeLengthPrefixedString("row1", strategy: .mySQL)
+            }
+            try await channel.writeInbound(row1Packet)
+
+            #expect(channel.isActive)
+
+            let row2Packet = NIOAsyncTestingChannel.makeMySQLPacket(sequenceID: 4) { buffer in
+                buffer.writeLengthPrefixedString("row2", strategy: .mySQL)
+            }
+            try await channel.writeInbound(row2Packet)
+            let okPacket = OKPacket(
+                affectedRows: 0,
+                lastInsertID: 0,
+                serverStatus: [],
+                warningCount: 0,
+                info: "",
+                newSchema: nil,
+                updatedSettings: [:],
+                generalStateChange: false
+            )
+            let okPacketBuffer = NIOAsyncTestingChannel.makeMySQLPacket(sequenceID: 5) { buffer in
+                okPacket.write(to: &buffer, capabilities: .baselineClientCapabilities)
+            }
+            try await channel.writeInbound(okPacketBuffer)
+
+            #expect(!channel.isActive)
+
+            try await channel.closeFuture.get()
+        }
+    }
+
+    @Test("Cancellation")
+    func cancellation() async throws {
+        let (stream, continuation) = AsyncStream<Void>.makeStream()
+        try await withTestMySQLServer { connection in
+            try await withThrowingTaskGroup { group in
+                group.addTask {
+                    await #expect(throws: MySQLClientError.cancelled) {
+                        // This will be sent and become the active command
+                        async let firstCommand = connection.ping()
+
+                        try await Task.sleep(for: .milliseconds(50))
+
+                        // No need to process this second command from the server, as it will be cancelled before it is sent
+                        async let secondCommand = connection.ping()
+                        _ = try await (firstCommand, secondCommand)
+                    }
+                }
+
+                try await Task.sleep(for: .milliseconds(100))
+                // This is put in the command queue before the cancellation,
+                // but will not be cancelled and sent to the server after the first command is completed
+                async let thirdCommand = connection.ping()
+
+                // Wait until the server is in the middle of processing the command
+                await stream.first { _ in true }
+                group.cancelAll()
+
+                // Even after cancellation, the server can still process the third command
+                _ = try await thirdCommand
+
+                // The connection is still active so we can send more commands after the cancellation
+                await #expect(throws: Never.self) {
+                    try await connection.ping()
+                }
+            }
+        } server: { channel in
+            // Wait for all three commands to be sent
+            try await Task.sleep(for: .milliseconds(150))
+
+            let pingCommandPacket = try await channel.waitForOutboundWrite(as: ByteBuffer.self)
+            #expect(pingCommandPacket == ByteBuffer(bytes: [0x01, 0x00, 0x00, 0x00, 0x0E]))
+
+            // In the middle of processing the command, we cancel the task
+            continuation.yield()
+
+            // The server continues to process the command as it has no knowledge of the cancellation
+            let okPacket = OKPacket(
+                affectedRows: 0,
+                lastInsertID: 0,
+                serverStatus: [],
+                warningCount: 0,
+                info: "",
+                newSchema: nil,
+                updatedSettings: [:],
+                generalStateChange: false
+            )
+            let okPacketBuffer = NIOAsyncTestingChannel.makeMySQLPacket(sequenceID: 1) { buffer in
+                okPacket.write(to: &buffer, capabilities: .baselineClientCapabilities)
+            }
+            try await channel.writeInbound(okPacketBuffer)
+
+            // Connection is still active
+            #expect(channel.isActive)
+
+            // This is the `thirdCommand` sent before the cancellation
+            try await channel.processPing()
+
+            // This is the command sent after everything
+            try await channel.processPing()
+        }
+    }
+
+    @Test("Query Cancellation")
+    func queryCancellation() async throws {
+        let (stream, continuation) = AsyncStream<Void>.makeStream()
+        try await withTestMySQLServer { connection in
+            try await withThrowingTaskGroup { group in
+                group.addTask {
+                    try await connection.query("test") { rows in
+                        for try await row in rows {
+                            #expect(row.columns.count == 1)
+                            #expect(String(buffer: try #require(row.first?.bytes)) == "row1")
+                        }
+                    }
+                }
+
+                await stream.first { _ in true }
+                group.cancelAll()
+
+                try await group.waitForAll()
+
+                try await connection.ping()  // Connection is still active after the cancellation
+            }
+        } server: { channel in
+            let queryPacket = try await channel.waitForOutboundWrite(as: ByteBuffer.self)
+            #expect(queryPacket.getBytes(at: queryPacket.readerIndex + 4, length: 1) == [0x03])  // COM_QUERY command
+            let queryString = queryPacket.getString(at: queryPacket.readerIndex + 5, length: queryPacket.readableBytes - 5)
+            #expect(queryString == "test")
+            let resultsetMetadataPacket = NIOAsyncTestingChannel.makeMySQLPacket(sequenceID: 1) { buffer in
+                buffer.writeEncodedInteger(1, strategy: .mySQL)  // column count
+                // TODO: Fix crash when there is no column definitions (i.e. when `metadata_follows = 0`)
+                buffer.writeInteger(1, as: UInt8.self)  // metadata follows
+            }
+            try await channel.writeInbound(resultsetMetadataPacket)
+            let columnDefinitionPacket = NIOAsyncTestingChannel.makeMySQLPacket(sequenceID: 2) { buffer in
+                let columnDefinition = ColumnDefinition(
+                    schema: "schema",
+                    table: "table",
+                    orgTable: "orgTable",
+                    name: "name",
+                    orgName: "orgName",
+                    extendedMetadata: nil,
+                    characterSet: .utf8Unicode14AICI,
+                    columnLength: 255,
+                    dataType: .varchar,
+                    flags: 0,
+                    decimals: 0,
+                    format: .text
+                )
+                columnDefinition.write(to: &buffer, capabilities: .baselineClientCapabilities)
+            }
+            try await channel.writeInbound(columnDefinitionPacket)
+            let row1Packet = NIOAsyncTestingChannel.makeMySQLPacket(sequenceID: 3) { buffer in
+                buffer.writeLengthPrefixedString("row1", strategy: .mySQL)
+            }
+            try await channel.writeInbound(row1Packet)
+
+            // Cancel the query task
+            continuation.yield()
+            try await Task.sleep(for: .milliseconds(100))
+
+            // Send the second row anyway, the `MySQLRowSequence` will not return it
+            let row2Packet = NIOAsyncTestingChannel.makeMySQLPacket(sequenceID: 4) { buffer in
+                buffer.writeLengthPrefixedString("row2", strategy: .mySQL)
+            }
+            try await channel.writeInbound(row2Packet)
+            let okPacket = OKPacket(
+                affectedRows: 0,
+                lastInsertID: 0,
+                serverStatus: [],
+                warningCount: 0,
+                info: "",
+                newSchema: nil,
+                updatedSettings: [:],
+                generalStateChange: false
+            )
+            let okPacketBuffer = NIOAsyncTestingChannel.makeMySQLPacket(sequenceID: 5) { buffer in
+                okPacket.write(to: &buffer, capabilities: .baselineClientCapabilities)
+            }
+            try await channel.writeInbound(okPacketBuffer)
+
+            // Connection is still active
+            #expect(channel.isActive)
+
+            try await channel.processPing()  // This is the command sent after everything
+        }
+    }
 }

--- a/Tests/MySQLNIOTests/MySQLConnectionTests.swift
+++ b/Tests/MySQLNIOTests/MySQLConnectionTests.swift
@@ -37,54 +37,26 @@ struct MySQLConnectionTests {
                 #expect(String(buffer: try #require(thirdRow.first?.bytes)) == "row3")
             }
         } server: { channel in
-            let queryPacket = try await channel.waitForOutboundWrite(as: ByteBuffer.self)
-            #expect(queryPacket.getBytes(at: queryPacket.readerIndex + 4, length: 1) == [0x03])  // COM_QUERY command
-            let queryString = queryPacket.getString(at: queryPacket.readerIndex + 5, length: queryPacket.readableBytes - 5)
-            #expect(queryString == "test")
-            let resultsetMetadataPacket = NIOAsyncTestingChannel.makeMySQLPacket(sequenceID: 1) { buffer in
-                buffer.writeEncodedInteger(1, strategy: .mySQL)  // column count
-                // TODO: Fix crash when there is no column definitions (i.e. when `metadata_follows = 0`)
-                buffer.writeInteger(1, as: UInt8.self)  // metadata follows
-            }
-            try await channel.writeInbound(resultsetMetadataPacket)
-            let columnDefinitionPacket = NIOAsyncTestingChannel.makeMySQLPacket(sequenceID: 2) { buffer in
-                let columnDefinition = ColumnDefinition(
-                    schema: "schema",
-                    table: "table",
-                    orgTable: "orgTable",
-                    name: "name",
-                    orgName: "orgName",
-                    extendedMetadata: nil,
-                    characterSet: .utf8Unicode14AICI,
-                    columnLength: 255,
-                    dataType: .varchar,
-                    flags: 0,
-                    decimals: 0,
-                    format: .text
-                )
-                columnDefinition.write(to: &buffer, capabilities: .baselineClientCapabilities)
-            }
-            try await channel.writeInbound(columnDefinitionPacket)
-            for (i, row) in ["row1", "row2", "row3"].enumerated() {
-                let rowPacket = NIOAsyncTestingChannel.makeMySQLPacket(sequenceID: 3 + UInt8(i)) { buffer in
-                    buffer.writeLengthPrefixedString(row, strategy: .mySQL)
-                }
-                try await channel.writeInbound(rowPacket)
-            }
-            let okPacket = OKPacket(
-                affectedRows: 0,
-                lastInsertID: 0,
-                serverStatus: [],
-                warningCount: 0,
-                info: "",
-                newSchema: nil,
-                updatedSettings: [:],
-                generalStateChange: false
+            try await channel.processQuery(
+                "test",
+                columns: [
+                    .init(
+                        schema: "schema",
+                        table: "table",
+                        orgTable: "orgTable",
+                        name: "name",
+                        orgName: "orgName",
+                        extendedMetadata: nil,
+                        characterSet: .utf8Unicode14AICI,
+                        columnLength: 255,
+                        dataType: .varchar,
+                        flags: 0,
+                        decimals: 0,
+                        format: .text
+                    )
+                ],
+                rows: ["row1", "row2", "row3"]
             )
-            let okPacketBuffer = NIOAsyncTestingChannel.makeMySQLPacket(sequenceID: 6) { buffer in
-                okPacket.write(to: &buffer, capabilities: .baselineClientCapabilities)
-            }
-            try await channel.writeInbound(okPacketBuffer)
         }
     }
 }

--- a/Tests/MySQLNIOTests/Utils/withTestMySQLServer.swift
+++ b/Tests/MySQLNIOTests/Utils/withTestMySQLServer.swift
@@ -34,8 +34,11 @@ func withTestMySQLServer(
         }
         group.addTask {
             try await serverOperation(channel)
-            let quitPacket = try await channel.waitForOutboundWrite(as: ByteBuffer.self)
-            #expect(quitPacket == ByteBuffer(bytes: [0x01, 0x00, 0x00, 0x00, 0x01]))
+            // If the connection wasn't already closed (e.g. by a completed graceful shutdown), it will send COM_QUIT.
+            if channel.isActive {
+                let quitPacket = try await channel.waitForOutboundWrite(as: ByteBuffer.self)
+                #expect(quitPacket == ByteBuffer(bytes: [0x01, 0x00, 0x00, 0x00, 0x01]))
+            }
         }
         try await group.waitForAll()
     }

--- a/Tests/MySQLNIOTests/Utils/withTestMySQLServer.swift
+++ b/Tests/MySQLNIOTests/Utils/withTestMySQLServer.swift
@@ -138,4 +138,53 @@ extension NIOAsyncTestingChannel {
         }
         try await self.writeInbound(okPacketBuffer)
     }
+
+    /// Helper function to process a MySQL query command from the client and respond with the specified columns and rows.
+    ///
+    /// - Parameters:
+    ///   - query: The SQL query string sent by the client.
+    ///   - columns: An array of ``ColumnDefinition`` representing the columns in the result
+    ///   - rows: An array of strings representing the rows in the result set.
+    func processQuery(
+        _ query: String,
+        columns: [ColumnDefinition],
+        rows: [String]
+    ) async throws {
+        let queryPacket = try await self.waitForOutboundWrite(as: ByteBuffer.self)
+        #expect(queryPacket.getBytes(at: queryPacket.readerIndex + 4, length: 1) == [0x03])  // COM_QUERY command
+        let queryString = queryPacket.getString(at: queryPacket.readerIndex + 5, length: queryPacket.readableBytes - 5)
+        #expect(queryString == query)
+        let resultsetMetadataPacket = Self.makeMySQLPacket(sequenceID: 1) { buffer in
+            buffer.writeEncodedInteger(columns.count, strategy: .mySQL)  // column count
+            // TODO: Fix crash when there is no column definitions (i.e. when `metadata_follows = 0`)
+            buffer.writeInteger(1, as: UInt8.self)  // metadata follows
+        }
+        try await self.writeInbound(resultsetMetadataPacket)
+        for (i, column) in columns.enumerated() {
+            let columnDefinitionPacket = Self.makeMySQLPacket(sequenceID: UInt8(i + 2)) { buffer in
+                column.write(to: &buffer, capabilities: .baselineClientCapabilities)
+            }
+            try await self.writeInbound(columnDefinitionPacket)
+        }
+        for (i, row) in rows.enumerated() {
+            let rowPacket = Self.makeMySQLPacket(sequenceID: UInt8(i + 2 + columns.count)) { buffer in
+                buffer.writeLengthPrefixedString(row, strategy: .mySQL)
+            }
+            try await self.writeInbound(rowPacket)
+        }
+        let okPacket = OKPacket(
+            affectedRows: 0,
+            lastInsertID: 0,
+            serverStatus: [],
+            warningCount: 0,
+            info: "",
+            newSchema: nil,
+            updatedSettings: [:],
+            generalStateChange: false
+        )
+        let okPacketBuffer = NIOAsyncTestingChannel.makeMySQLPacket(sequenceID: 6) { buffer in
+            okPacket.write(to: &buffer, capabilities: .baselineClientCapabilities)
+        }
+        try await self.writeInbound(okPacketBuffer)
+    }
 }


### PR DESCRIPTION
- Correct the implementation of graceful shutdown
  - It was incorrectly executed in conjunction with the sending of `COM_QUIT` when the connection was closed
  - Now it is implemented just like in `valkey-swift`
  - It is now also handled correctly during the handshake and queries
- Don't close the connection when the `Task` a command is running on gets cancelled, and let the channel handler correctly drain all incoming packets for that command, to avoid corrupting the session
- Separate `COM_QUERY` promise completion from `MySQLRowSequence` completion
  - Basically before this fix `MySQLConnection.query` returned the `MySQLRowSequence` to the user only when the server finished sending the resultset, now the `PendingCommand` gets succeeded after the server has sent all column metadata and before receiving the rows, so the `MySQLRowSequence` correctly receives the rows as they come
- Only send `COM_QUIT` if the channel is still active
- Add tests
- Various other small fixes